### PR TITLE
Add "Material (auto)" theme that follows the system dark/light mode.

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/WelcomeActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/WelcomeActivity.java
@@ -15,7 +15,6 @@ import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
 
-import com.google.android.material.button.MaterialButton;
 import com.google.android.material.switchmaterial.SwitchMaterial;
 import com.simon.harmonichackernews.utils.ThemeUtils;
 import com.simon.harmonichackernews.utils.Utils;
@@ -33,6 +32,7 @@ public class WelcomeActivity extends AppCompatActivity {
         ImageView favicon = findViewById(R.id.story_meta_favicon);
         TextView index = findViewById(R.id.story_index);
         TextView meta = findViewById(R.id.story_meta);
+        Button materialDaynightButton = findViewById(R.id.welcome_button_material_daynight);
         Button materialDarkButton = findViewById(R.id.welcome_button_material_dark);
         Button materialLightButton = findViewById(R.id.welcome_button_material_light);
         Button darkButton = findViewById(R.id.welcome_button_dark);
@@ -81,6 +81,7 @@ public class WelcomeActivity extends AppCompatActivity {
             }
         };
 
+        materialDaynightButton.setOnClickListener(buttonClickListener);
         materialDarkButton.setOnClickListener(buttonClickListener);
         materialLightButton.setOnClickListener(buttonClickListener);
         darkButton.setOnClickListener(buttonClickListener);

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.view.View;
 
 import androidx.preference.PreferenceManager;
@@ -28,6 +29,9 @@ public class ThemeUtils {
     public static void setupTheme(Activity activity, boolean swipeBack, boolean specialFlags) {
         String theme = getPreferredTheme(activity);
         switch (theme) {
+            case "material_daynight":
+                activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBarMaterialDayNight : R.style.AppThemeMaterialDayNight);
+                break;
             case "material_dark":
                 activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBarMaterialDark : R.style.AppThemeMaterialDark);
                 break;
@@ -59,7 +63,16 @@ public class ThemeUtils {
 
     public static boolean isDarkMode(Context ctx) {
         String theme = getPreferredTheme(ctx);
+        if (theme.equals("material_daynight")) {
+            return uiModeNight(ctx);
+        }
         return theme.equals("amoled") || theme.equals("dark") || theme.equals("gray") || theme.equals("material_dark");
+    }
+
+    public static boolean uiModeNight(Context ctx) {
+        int currentNightMode = ctx.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        boolean isNight = currentNightMode == Configuration.UI_MODE_NIGHT_YES;
+        return isNight;
     }
 
     public static int getBackgroundColorResource(Context ctx) {
@@ -77,6 +90,8 @@ public class ThemeUtils {
                 return R.color.material_you_neutral_900;
             case "material_light":
                 return R.color.material_you_neutral_100;
+            case "material_daynight":
+                return uiModeNight(ctx) ? R.color.material_you_neutral_900 : R.color.material_you_neutral_100;
             default:
                 return R.color.background;
         }

--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -75,11 +75,23 @@
             android:layout_height="wrap_content">
 
             <Button
+                android:id="@+id/welcome_button_material_daynight"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="right"
+                android:layout_weight="1"
+                android:tag="material_daynight"
+                android:text="Material You (auto)"
+                android:textColor="?attr/storyColorNormal" />
+
+            <Button
                 style="?attr/materialButtonOutlinedStyle"
                 android:id="@+id/welcome_button_material_dark"
                 android:textColor="?attr/storyColorNormal"
                 android:layout_width="0dp"
                 android:layout_weight="1"
+                android:layout_marginLeft="8dp"
                 android:layout_marginRight="8dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
@@ -92,7 +104,6 @@
                 android:textColor="?attr/storyColorNormal"
                 android:layout_width="0dp"
                 android:layout_weight="1"
-                android:layout_marginLeft="8dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
                 android:tag="material_light"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,7 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="AppThemeMaterialDayNight" parent="AppThemeMaterialDark"></style>
+
+    <style name="ThemeSwipeBackNoActionBarMaterialDayNight" parent="ThemeSwipeBackNoActionBarMaterialDark"></style>
+
+</resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -18,6 +18,7 @@
     </string-array>
 
     <string-array name="theme_entries">
+        <item>Material You (auto)</item>
         <item>Dark</item>
         <item>Material You (dark)</item>
         <item>Gray</item>
@@ -28,6 +29,7 @@
     </string-array>
 
     <string-array name="theme_values">
+        <item>material_daynight</item>
         <item>dark</item>
         <item>material_dark</item>
         <item>gray</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
+    <style name="AppThemeMaterialDayNight" parent="AppThemeMaterialLight"></style>
+
     <style name="AppThemeMaterialDark" parent="Theme.Material3.Dark.NoActionBar">
         <item name="storyColorNormal">@color/darkStoryColorNormal</item>
         <item name="storyColorDisabled">@color/darkStoryColorDisabled</item>
@@ -144,6 +146,8 @@
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
+
+    <style name="ThemeSwipeBackNoActionBarMaterialDayNight" parent="ThemeSwipeBackNoActionBarMaterialLight"></style>
 
     <style name="ThemeSwipeBackNoActionBarMaterialDark" parent="AppThemeMaterialDark">
         <item name="android:windowIsTranslucent">true</item>


### PR DESCRIPTION
Thanks for the great app!  I've wanted a dark mode for HN for a long time :)

This new theme automatically follows the system dark/light mode.  Given the existing theme and day/night timer, a new theme seemed like the cleanest way to add support for keeping the app's theme in-sync with the system.

Most of the magic is handled by values-night/theme.xml, but the comments action had a few things I needed to handle in onStart.  I haven't done Android development before, but this seemed like the right way to go about it.

Feel free to integrate (or not) this pull request as you see fit.  I won't be offended either way.