### PR TITLE
fix exception when loading user without submissions

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/UserDialogFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/UserDialogFragment.java
@@ -106,7 +106,15 @@ public class UserDialogFragment extends AppCompatDialogFragment {
                             int karma = jsonObject.getInt("karma");
                             Calendar cal = Calendar.getInstance();
                             cal.setTime(new Date(jsonObject.getInt("created") * 1000L));
-                            JSONArray submitted = jsonObject.getJSONArray("submitted");
+
+                            // Users who have never submitted before do not receive this key as part of their response.
+                            JSONArray submitted = null;
+                            if (jsonObject.has("submitted")) {
+                                submitted = jsonObject.getJSONArray("submitted");
+                            } else {
+                                submitted = new JSONArray();
+                                jsonObject.put("submitted", submitted);
+                            }
 
                             if (submitted.length() == 0) {
                                 submissionsButton.setVisibility(View.GONE);


### PR DESCRIPTION
This pull request is to fix an issue with users that do not have a "submissions" key.

If you look at the response for my username, https://hacker-news.firebaseio.com/v0/user/tukajo.json

It returns the following JSON

```
{"created":1650837729,"id":"tukajo","karma":1}

```

This causes an exception to be thrown when the `getJsonArray` is called, which causes the modal to never be able to render the user profile (no matter how many retries).

Addresses #10 