### PR TITLE
Set correct status bar color when writing comments

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
@@ -1,18 +1,17 @@
 package com.simon.harmonichackernews.utils;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
-import android.view.View;
+import android.view.Window;
 
+import androidx.core.view.WindowCompat;
 import androidx.preference.PreferenceManager;
 
 import com.simon.harmonichackernews.R;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -52,12 +51,12 @@ public class ThemeUtils {
                 break;
         }
 
+	Window window = activity.getWindow();
+        WindowCompat.getInsetsController(window, window.getDecorView())
+                .setAppearanceLightStatusBars(!isDarkMode(activity));
+
         if (specialFlags) {
-            if (isDarkMode(activity)) {
-                activity.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
-            } else {
-                activity.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-            }
+            WindowCompat.setDecorFitsSystemWindows(window, false);
         }
     }
 

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
@@ -51,7 +51,7 @@ public class ThemeUtils {
                 break;
         }
 
-	Window window = activity.getWindow();
+	    Window window = activity.getWindow();
         WindowCompat.getInsetsController(window, window.getDecorView())
                 .setAppearanceLightStatusBars(!isDarkMode(activity));
 


### PR DESCRIPTION
Because `ComposeActivity` was the only place calling `ThemeUtils.setupTheme` with `specialFlags=false`, its status bar was not updated in light theme. Now it is always updated to match theme color

Before:
![sb_compose(1)](https://github.com/SimonHalvdansson/Harmonic-HN/assets/133590454/089995c3-5ae0-4bf6-8781-d6ca1a6e5a8c)

After:
![sb_fix(1)](https://github.com/SimonHalvdansson/Harmonic-HN/assets/133590454/683236a9-5a88-4f23-ba5e-e3297bde8306)
