### PR TITLE
Keep search text in UI

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -592,6 +592,7 @@ public class StoriesFragment extends Fragment {
 
     private void search(String query, boolean relevance, String age) {
         lastSearch = query;
+        adapter.lastSearch = query;
         lastSearchRelevance = relevance;
         lastSearchAge = age;
 

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -651,6 +651,7 @@ public class StoriesFragment extends Fragment {
     public boolean exitSearch() {
         if (adapter.searching) {
             adapter.searching = false;
+            adapter.lastSearch = "";
             updateSearchStatus();
             return true;
         }

--- a/app/src/main/java/com/simon/harmonichackernews/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoryRecyclerViewAdapter.java
@@ -88,6 +88,8 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
     public int type = 0;
     public boolean searching = false;
 
+    public String lastSearch = "";
+
     public StoryRecyclerViewAdapter(List<Story> items,
                                     boolean shouldShowPoints,
                                     boolean shouldUseCompactView,
@@ -270,6 +272,8 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
 
             if (searching) {
                 headerViewHolder.searchEditText.requestFocus();
+                headerViewHolder.searchEditText.setText(lastSearch);
+                headerViewHolder.searchEditText.setSelection(lastSearch.length());
 
                 headerViewHolder.searchEmptyContainer.setVisibility(stories.size() == 1 ? View.VISIBLE : View.GONE);
                 headerViewHolder.noBookmarksLayout.setVisibility(View.GONE);
@@ -467,6 +471,7 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
                         imm.toggleSoftInput(InputMethodManager.SHOW_IMPLICIT, 0);
                     } else {
                         imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+                        lastSearch = "";
                     }
                 }
             });


### PR DESCRIPTION
The search text previously disappeared once the result loaded which was quite frustrating when you wanted to adjust the query.

Now the UI keeps the showing the search text even after the results are loaded.