### PR TITLE
Remove unnecessary layout inflations

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -247,13 +247,6 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
         }
     }
 
-    @Nullable
-    @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        inflater.inflate(R.layout.fragment_comments, container, false);
-        return super.onCreateView(inflater, container, savedInstanceState);
-    }
-
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -88,7 +88,6 @@ public class StoriesFragment extends Fragment {
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        inflater.inflate(R.layout.fragment_stories, container, false);
         clickedIds = SettingsUtils.readIntSetFromSharedPreferences(requireContext(), Utils.KEY_SHARED_PREFERENCES_CLICKED_IDS);
 
         return super.onCreateView(inflater, container, savedInstanceState);


### PR DESCRIPTION
The result of these inflations is not used and actual layout inflation
is performed by parent class, so they can be safely removed.

NB: I didn't bother to benchmark if there is any startup speed
difference, but it should be ever so slightly faster.
