### PR TITLE
Disable refresh while typing the search query

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -244,12 +244,6 @@ public class StoriesFragment extends Fragment {
                 attemptRefresh();
             }
         });
-        adapter.setRefreshEnabler(new StoryRecyclerViewAdapter.RefreshEnabler() {
-            @Override
-            public void enable(boolean enabled) {
-                swipeRefreshLayout.setEnabled(enabled);
-            }
-        });
 
         adapter.setSearchListener(new StoryRecyclerViewAdapter.SearchListener() {
             @Override
@@ -572,6 +566,8 @@ public class StoriesFragment extends Fragment {
         if (getActivity() != null && getActivity() instanceof MainActivity) {
             ((MainActivity) getActivity()).backPressedCallback.setEnabled(adapter.searching);
         }
+
+        swipeRefreshLayout.setEnabled(!adapter.searching)
 
         if (adapter.searching) {
             //cancel all ongoing

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -4,7 +4,6 @@ import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -243,6 +242,12 @@ public class StoriesFragment extends Fragment {
             if (index != currentType) {
                 currentType = index;
                 attemptRefresh();
+            }
+        });
+        adapter.setRefreshEnabler(new StoryRecyclerViewAdapter.RefreshEnabler() {
+            @Override
+            public void enable(boolean enabled) {
+                swipeRefreshLayout.setEnabled(enabled);
             }
         });
 
@@ -505,7 +510,7 @@ public class StoriesFragment extends Fragment {
                 Story s = new Story("Loading...", bookmarks.get(i).id, false, false);
 
                 stories.add(s);
-                adapter.notifyItemInserted( i + 1);
+                adapter.notifyItemInserted(i + 1);
                 if (i < 20) {
                     loadStory(stories.get(i + 1), 0);
                 }
@@ -526,7 +531,7 @@ public class StoriesFragment extends Fragment {
 
                         loadedTo = 0;
 
-                        adapter.notifyItemRangeRemoved(1, stories.size()+1);
+                        adapter.notifyItemRangeRemoved(1, stories.size() + 1);
 
                         stories.clear();
                         stories.add(new Story());
@@ -542,7 +547,7 @@ public class StoriesFragment extends Fragment {
                             }
 
                             stories.add(s);
-                            adapter.notifyItemInserted(1+i);
+                            adapter.notifyItemInserted(1 + i);
                         }
 
                         adapter.loadingFailed = false;
@@ -601,6 +606,7 @@ public class StoriesFragment extends Fragment {
     }
 
     private void loadAlgolia(String url, boolean markClicked) {
+        swipeRefreshLayout.setEnabled(true);
         swipeRefreshLayout.setRefreshing(true);
         StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
                 response -> {
@@ -653,6 +659,7 @@ public class StoriesFragment extends Fragment {
         if (adapter.searching) {
             adapter.searching = false;
             adapter.lastSearch = "";
+            swipeRefreshLayout.setEnabled(true);
             updateSearchStatus();
             return true;
         }
@@ -662,7 +669,7 @@ public class StoriesFragment extends Fragment {
     private void hideUpdateButton() {
         if (updateContainer.getVisibility() == View.VISIBLE) {
 
-            float endYPosition = getResources().getDisplayMetrics().heightPixels-updateContainer.getY() + updateContainer.getHeight() + ViewUtils.getNavigationBarHeight(getResources());
+            float endYPosition = getResources().getDisplayMetrics().heightPixels - updateContainer.getY() + updateContainer.getHeight() + ViewUtils.getNavigationBarHeight(getResources());
             PathInterpolator pathInterpolator = new PathInterpolator(0.3f, 0f, 0.8f, 0.15f);
 
             ObjectAnimator yAnimator = ObjectAnimator.ofFloat(updateContainer, "translationY", endYPosition);

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -567,7 +567,7 @@ public class StoriesFragment extends Fragment {
             ((MainActivity) getActivity()).backPressedCallback.setEnabled(adapter.searching);
         }
 
-        swipeRefreshLayout.setEnabled(!adapter.searching)
+        swipeRefreshLayout.setEnabled(!adapter.searching);
 
         if (adapter.searching) {
             //cancel all ongoing
@@ -655,7 +655,6 @@ public class StoriesFragment extends Fragment {
         if (adapter.searching) {
             adapter.searching = false;
             adapter.lastSearch = "";
-            swipeRefreshLayout.setEnabled(true);
             updateSearchStatus();
             return true;
         }

--- a/app/src/main/java/com/simon/harmonichackernews/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoryRecyclerViewAdapter.java
@@ -53,6 +53,7 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
     private ClickListener commentStoryClickListener;
     private SearchListener storiesSearchListener;
     private RefreshListener refreshListener;
+    private RefreshEnabler refreshEnabler;
     private View.OnClickListener moreClickListener;
     private final boolean atSubmissions;
     private final String submitter;
@@ -450,6 +451,7 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
                 @Override
                 public void onClick(View view) {
                     searching = !searching;
+                    refreshEnabler.enable(!searching);
                     storiesSearchListener.onSearchStatusChanged();
 
                     InputMethodManager imm = (InputMethodManager) ctx.getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -583,12 +585,21 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
         storiesSearchListener = searchListener;
     }
 
+    public void setRefreshEnabler(RefreshEnabler refreshEnabler) {
+        this.refreshEnabler = refreshEnabler;
+    }
+
     public interface SearchListener {
         void onQueryTextSubmit(String query, boolean relevance, String age);
+
         void onSearchStatusChanged();
     }
 
     public interface RefreshListener {
         void onRefresh();
+    }
+
+    public interface RefreshEnabler {
+        void enable(boolean enabled);
     }
 }

--- a/app/src/main/java/com/simon/harmonichackernews/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoryRecyclerViewAdapter.java
@@ -53,7 +53,6 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
     private ClickListener commentStoryClickListener;
     private SearchListener storiesSearchListener;
     private RefreshListener refreshListener;
-    private RefreshEnabler refreshEnabler;
     private View.OnClickListener moreClickListener;
     private final boolean atSubmissions;
     private final String submitter;
@@ -451,7 +450,6 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
                 @Override
                 public void onClick(View view) {
                     searching = !searching;
-                    refreshEnabler.enable(!searching);
                     storiesSearchListener.onSearchStatusChanged();
 
                     InputMethodManager imm = (InputMethodManager) ctx.getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -487,7 +485,6 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
             storiesSearchListener.onQueryTextSubmit(searchEditText.getText().toString(), popRecAuto.getText().equals("Popularity"), timeScaleAuto.getText().toString());
         }
     }
-
 
 
     public class SubmissionsHeaderViewHolder extends RecyclerView.ViewHolder {
@@ -585,9 +582,6 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
         storiesSearchListener = searchListener;
     }
 
-    public void setRefreshEnabler(RefreshEnabler refreshEnabler) {
-        this.refreshEnabler = refreshEnabler;
-    }
 
     public interface SearchListener {
         void onQueryTextSubmit(String query, boolean relevance, String age);
@@ -597,9 +591,5 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
 
     public interface RefreshListener {
         void onRefresh();
-    }
-
-    public interface RefreshEnabler {
-        void enable(boolean enabled);
     }
 }

--- a/app/src/main/java/com/simon/harmonichackernews/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoryRecyclerViewAdapter.java
@@ -582,10 +582,8 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
         storiesSearchListener = searchListener;
     }
 
-
     public interface SearchListener {
         void onQueryTextSubmit(String query, boolean relevance, String age);
-
         void onSearchStatusChanged();
     }
 


### PR DESCRIPTION
There is no logical reason to refresh while you are typing. However, the refresh would have revealed an invalid cache and would start loading the results from the previous search.

You could reproduce this with:
1. Search something
2. Go to the main screen
3. Go to the search
4. Refresh by pulling from the top

Now the refresh gesture is disabled while you are in the search and no results have been loaded.