### PR TITLE
Fix webview exception

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -829,7 +829,6 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
         webViewContainer.removeAllViews();
         webView.clearHistory();
         webView.clearCache(true);
-        webView.loadUrl("about:blank");
         webView.onPause();
         webView.removeAllViews();
         webView.destroyDrawingCache();


### PR DESCRIPTION
The webview threw an exception when it was destroyed. This exception was thrown because before destroying it was instructed to load about:blank which happened asynchronously in the background. Sometimes before it finished loading it we would first call `destroy` and when the loading was finished it wanted to modify the webview. However after calling `destroy` it is not allowed to call anything on the webview and the exception was raised.

This didn't always happen and some sites were more prone to it which I assume is because they took longer to unload before about:blank could be loaded.

Loading about:blank before permanently destroying the webview isn't that useful and anyway and the stackoverflow post that introduced that pattern doesn't explain it so I guess it should be save to remove.