### PR TITLE
Rework comments screen paddings

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -544,13 +544,31 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
             recyclerView.setItemAnimator(null);
         }
 
+        BottomSheetBehavior.from(bottomSheet).addBottomSheetCallback(new BottomSheetBehavior.BottomSheetCallback() {
+            @Override
+            public void onStateChanged(@NonNull View view, int newState) {
+            }
+
+            @Override
+            public void onSlide(@NonNull View view, float slideOffset) {
+                // Updating padding doesn't work because it causes incorrect scroll position for recycler.
+                // Updating scroll together with padding causes severe lags and other problems.
+                // So don't update padding at all on slide and instead just change whole view position
+                recyclerView.setTranslationY(-recyclerView.getPaddingTop() * (1 - slideOffset));
+            }
+        });
+
         ViewCompat.setOnApplyWindowInsetsListener(recyclerView, new OnApplyWindowInsetsListener() {
             @NonNull
             @Override
             public WindowInsetsCompat onApplyWindowInsets(@NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
                 Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
 
-                recyclerView.setPadding(0,0,0, insets.bottom + getResources().getDimensionPixelSize(showNavButtons ? R.dimen.comments_bottom_navigation : R.dimen.comments_bottom_standard));
+                float offset = BottomSheetBehavior.from(bottomSheet).calculateSlideOffset();
+                recyclerView.setTranslationY(insets.top * (1 - offset));
+
+                int paddingBottom = insets.bottom + getResources().getDimensionPixelSize(showNavButtons ? R.dimen.comments_bottom_navigation : R.dimen.comments_bottom_standard);
+                recyclerView.setPadding(recyclerView.getPaddingLeft(), insets.top, recyclerView.getPaddingRight(), paddingBottom);
 
                 return windowInsets;
             }

--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -306,12 +306,11 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
                 Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
                 updateBottomSheetMargin(insets.bottom);
 
+                webViewContainer.setPadding(0, insets.top, 0, 0);
                 return windowInsets;
             }
         });
         ViewUtils.requestApplyInsetsWhenAttached(view);
-
-        webViewContainer.setPadding(0, ViewUtils.getStatusBarHeight(getResources()), 0, 0);
 
         if (!showWebsite) {
             BottomSheetBehavior.from(bottomSheet).setState(BottomSheetBehavior.STATE_EXPANDED);

--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -156,8 +156,6 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
     private String username;
     private Story story;
 
-    private int topInset;
-
     public CommentsFragment() {
         super(R.layout.fragment_comments);
     }
@@ -354,8 +352,6 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
                 FrameLayout.LayoutParams scrollParams = (FrameLayout.LayoutParams) scrollNavigation.getLayoutParams();
                 scrollParams.setMargins(0,0,0, insets.bottom + Utils.pxFromDpInt(getResources(), 16));
 
-                topInset = insets.top;
-
                 return windowInsets;
             }
         });
@@ -368,24 +364,12 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
         ImageButton scrollNext = view.findViewById(R.id.comments_scroll_next);
         ImageView scrollIcon = view.findViewById(R.id.comments_scroll_icon);
 
-        RecyclerView.SmoothScroller smoothScroller = new LinearSmoothScroller(requireContext()) {
-            @Override protected int getVerticalSnapPreference() {
-                return LinearSmoothScroller.SNAP_TO_START;
-            }
-
-            @Override
-            public int calculateDyToMakeVisible(View view, int snapPreference) {
-                int standardDy = super.calculateDyToMakeVisible(view, snapPreference);
-                return standardDy + topInset;
-            }
-        };
-
         scrollIcon.setOnClickListener(null);
 
-        scrollNext.setOnClickListener((v) -> scrollNext(smoothScroller));
-        scrollNext.setOnLongClickListener(v -> {scrollLast(smoothScroller); return true;});
+        scrollNext.setOnClickListener((v) -> scrollNext());
+        scrollNext.setOnLongClickListener(v -> {scrollLast(); return true;});
 
-        scrollPrev.setOnClickListener((v) -> scrollPrevious(smoothScroller));
+        scrollPrev.setOnClickListener((v) -> scrollPrevious());
         scrollPrev.setOnLongClickListener(v -> {scrollTop(); return true;});
 
         initializeRecyclerView();
@@ -1113,60 +1097,49 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
         }
     }
 
-    private void scrollPrevious(RecyclerView.SmoothScroller smoothScroller) {
+    private void scrollPrevious() {
         LinearLayoutManager layoutManager = (LinearLayoutManager) recyclerView.getLayoutManager();
         if (layoutManager != null) {
             int firstVisible = layoutManager.findFirstVisibleItemPosition();
 
             int toScrollTo = 0;
 
-            for (int i = firstVisible; i >=0; i--) {
-                if (comments.get(i).depth == 0) {
+            for (int i = 0; i < firstVisible; i++) {
+                if (comments.get(i).depth == 0 || i == 0) {
                     toScrollTo = i;
-                    break;
                 }
             }
 
-            smoothScroller.setTargetPosition(toScrollTo);
-            layoutManager.startSmoothScroll(smoothScroller);
+            recyclerView.smoothScrollToPosition(toScrollTo);
         }
     }
 
-    public void scrollNext(RecyclerView.SmoothScroller smoothScroller) {
+    public void scrollNext() {
         LinearLayoutManager layoutManager = (LinearLayoutManager) recyclerView.getLayoutManager();
         if (layoutManager != null) {
-            /*
-            * Ideally, we want to use LayoutManager..findFirstVisibleItemPosition(); as I strongly
-            * suspect that this is faster than our home grown solution
-            * findTrueFirstVisibleItemPosition(layoutManager) - hence we need this logic to handle
-            * the special case where the first visible position is 0 when the standard solution
-            * does not work (due to window insets).
-            * */
-
             int firstVisible = layoutManager.findFirstVisibleItemPosition();
-            int toScrollTo = firstVisible+1;
+            int toScrollTo = firstVisible;
 
-            int searchOffset = 2;
-
-            if (firstVisible == 0) {
-                firstVisible = findTrueFirstVisibleItemPosition(layoutManager);
-                toScrollTo = firstVisible;
-                searchOffset = 1;
-            }
-
-            for (int i = firstVisible + searchOffset; i < comments.size(); i++) {
+            for (int i = firstVisible + 1; i < comments.size(); i++) {
                 if (comments.get(i).depth == 0) {
                     toScrollTo = i;
                     break;
                 }
             }
 
+            RecyclerView.SmoothScroller smoothScroller = new LinearSmoothScroller(requireContext()) {
+                @Override protected int getVerticalSnapPreference() {
+                    return LinearSmoothScroller.SNAP_TO_START;
+                }
+            };
+
             smoothScroller.setTargetPosition(toScrollTo);
             layoutManager.startSmoothScroll(smoothScroller);
+
         }
     }
 
-    private void scrollLast(RecyclerView.SmoothScroller smoothScroller) {
+    private void scrollLast() {
         LinearLayoutManager layoutManager = (LinearLayoutManager) recyclerView.getLayoutManager();
         if (layoutManager != null) {
             int firstVisible = layoutManager.findFirstVisibleItemPosition();
@@ -1178,21 +1151,15 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
                 }
             }
 
+            RecyclerView.SmoothScroller smoothScroller = new LinearSmoothScroller(requireContext()) {
+                @Override protected int getVerticalSnapPreference() {
+                    return LinearSmoothScroller.SNAP_TO_START;
+                }
+            };
+
             smoothScroller.setTargetPosition(toScrollTo);
             layoutManager.startSmoothScroll(smoothScroller);
         }
-    }
-
-    private int findTrueFirstVisibleItemPosition(LinearLayoutManager layoutManager) {
-        final int offset = topInset;
-        int childCount = layoutManager.getChildCount();
-        for (int i = 0; i < childCount; i++) {
-            View child = layoutManager.getChildAt(i);
-            if (child != null && child.getTop() + offset >= 0) {
-                return layoutManager.getPosition(child);
-            }
-        }
-        return layoutManager.findFirstVisibleItemPosition();
     }
 
     private void updateNavigationVisibility() {

--- a/app/src/main/java/com/simon/harmonichackernews/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsRecyclerViewAdapter.java
@@ -592,7 +592,6 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
             });
 
             LinearLayout sheetButtonsContainer = view.findViewById(R.id.comment_sheet_buttons_container);
-            LinearLayout sheetContainer = view.findViewById(R.id.comment_sheet_container);
             BottomSheetBehavior.from(bottomSheet).addBottomSheetCallback(new BottomSheetBehavior.BottomSheetCallback() {
                 @Override
                 public void onStateChanged(@NonNull View bottomSheet, int newState) {
@@ -604,7 +603,6 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                     sheetButtonsContainer.setAlpha((1-slideOffset)*(1-slideOffset)*(1-slideOffset));
                     sheetButtonsContainer.getLayoutParams().height = Math.round((1-slideOffset) * (SHEET_ITEM_HEIGHT + navbarHeight));
                     sheetButtonsContainer.requestLayout();
-                    sheetContainer.setPadding(0, (int) ((slideOffset) * ViewUtils.getStatusBarHeight(bottomSheet.getResources())), 0, 0);
 
                     float headerAlpha = Math.min(1, slideOffset*slideOffset*20);
                     actionsContainer.setAlpha(headerAlpha);
@@ -618,18 +616,15 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                     sheetButtonsContainer.setAlpha(0f);
                     sheetButtonsContainer.getLayoutParams().height = 0;
                     sheetButtonsContainer.requestLayout();
-                    sheetContainer.setPadding(0, ViewUtils.getStatusBarHeight(view.getResources()), 0, 0);
                 } else {
                     //make sure we set correct height when starting on the webview
                     sheetButtonsContainer.getLayoutParams().height = SHEET_ITEM_HEIGHT + navbarHeight;
                     sheetButtonsContainer.requestLayout();
-                    sheetContainer.setPadding(0, 0, 0, 0);
                 }
             } else {
                 moreLayoutParent.setVisibility(View.GONE);
                 sheetButtonsContainer.setVisibility(View.GONE);
                 view.findViewById(R.id.comments_sheet_handle).setVisibility(View.GONE);
-                sheetContainer.setPadding(0, ViewUtils.getStatusBarHeight(view.getResources()), 0, 0);
             }
         }
     }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ViewUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ViewUtils.java
@@ -62,14 +62,6 @@ public class ViewUtils {
         }
     }
 
-    public static int getStatusBarHeight(Resources res) {
-        int resourceId = res.getIdentifier("status_bar_height", "dimen", "android");
-        if (resourceId > 0) {
-            return  res.getDimensionPixelSize(resourceId);
-        }
-        return 0;
-    }
-
     public static int getNavigationBarHeight(Resources res) {
         int resourceId = res.getIdentifier("navigation_bar_height", "dimen", "android");
         if (resourceId > 0) {


### PR DESCRIPTION
Reworked paddings in comments screen with the same approach as other screens. Also since now recycler has padding equal to status bar, the fix for #61 is not necessary and default scroll behavior will be correct.

Also removed all usages of `ViewUtils.getStatusBarHeight` which is nice.
