### PR TITLE
Use singletons for OkHttp and Volley classes

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -36,11 +36,10 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.StringRequest;
-import com.android.volley.toolbox.Volley;
 import com.simon.harmonichackernews.data.Bookmark;
 import com.simon.harmonichackernews.data.Story;
 import com.simon.harmonichackernews.network.JSONParser;
-import com.simon.harmonichackernews.network.VolleyOkHttp3StackInterceptors;
+import com.simon.harmonichackernews.network.NetworkComponent;
 import com.simon.harmonichackernews.utils.AccountUtils;
 import com.simon.harmonichackernews.utils.FontUtils;
 import com.simon.harmonichackernews.utils.SettingsUtils;
@@ -67,6 +66,7 @@ public class StoriesFragment extends Fragment {
     private StoryRecyclerViewAdapter adapter;
     private List<Story> stories;
     private RequestQueue queue;
+    private final Object requestTag = new Object();
     private LinearLayoutManager linearLayoutManager;
     private Set<Integer> clickedIds;
     private ArrayList<String> filterWords;
@@ -161,7 +161,7 @@ public class StoriesFragment extends Fragment {
             }
         });
 
-        queue = Volley.newRequestQueue(requireContext(), new VolleyOkHttp3StackInterceptors());
+        queue = NetworkComponent.getRequestQueueInstance(requireContext());
         stories.add(new Story());
         attemptRefresh();
 
@@ -393,8 +393,7 @@ public class StoriesFragment extends Fragment {
     public void onDestroy() {
         super.onDestroy();
         if (queue != null) {
-            queue.cancelAll(request -> true);
-            queue.stop();
+            queue.cancelAll(requestTag);
         }
     }
 
@@ -472,6 +471,7 @@ public class StoriesFragment extends Fragment {
             loadStory(story, attempt + 1);
         });
 
+        stringRequest.setTag(requestTag);
         queue.add(stringRequest);
     }
 
@@ -518,7 +518,7 @@ public class StoriesFragment extends Fragment {
         swipeRefreshLayout.setRefreshing(true);
 
         //cancel all ongoing
-        queue.cancelAll(request -> true);
+        queue.cancelAll(requestTag);
 
         adapter.type = currentType;
 
@@ -611,6 +611,7 @@ public class StoriesFragment extends Fragment {
             adapter.notifyItemChanged(0);
         });
 
+        stringRequest.setTag(requestTag);
         queue.add(stringRequest);
     }
 
@@ -626,7 +627,7 @@ public class StoriesFragment extends Fragment {
 
         if (adapter.searching) {
             //cancel all ongoing
-            queue.cancelAll(request -> true);
+            queue.cancelAll(requestTag);
             swipeRefreshLayout.setRefreshing(false);
 
             adapter.notifyItemRangeRemoved(1, stories.size() + 1);
@@ -698,6 +699,7 @@ public class StoriesFragment extends Fragment {
             adapter.notifyItemChanged(0);
         });
 
+        stringRequest.setTag(requestTag);
         queue.add(stringRequest);
     }
 

--- a/app/src/main/java/com/simon/harmonichackernews/SubmissionsActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/SubmissionsActivity.java
@@ -15,11 +15,10 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.StringRequest;
-import com.android.volley.toolbox.Volley;
 import com.gw.swipeback.SwipeBackLayout;
 import com.simon.harmonichackernews.data.Story;
 import com.simon.harmonichackernews.network.JSONParser;
-import com.simon.harmonichackernews.network.VolleyOkHttp3StackInterceptors;
+import com.simon.harmonichackernews.network.NetworkComponent;
 import com.simon.harmonichackernews.utils.SettingsUtils;
 import com.simon.harmonichackernews.utils.SplitChangeHandler;
 import com.simon.harmonichackernews.utils.ThemeUtils;
@@ -81,7 +80,7 @@ public class SubmissionsActivity extends AppCompatActivity {
         //header
         submissions.add(new Story());
 
-        queue = Volley.newRequestQueue(this, new VolleyOkHttp3StackInterceptors());
+        queue = NetworkComponent.getRequestQueueInstance(this);
 
         linearLayoutManager = new LinearLayoutManager(this);
         recyclerView.setLayoutManager(linearLayoutManager);

--- a/app/src/main/java/com/simon/harmonichackernews/UserDialogFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/UserDialogFragment.java
@@ -24,9 +24,8 @@ import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.StringRequest;
-import com.android.volley.toolbox.Volley;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.simon.harmonichackernews.network.VolleyOkHttp3StackInterceptors;
+import com.simon.harmonichackernews.network.NetworkComponent;
 import com.simon.harmonichackernews.utils.Utils;
 
 import org.json.JSONArray;
@@ -62,7 +61,7 @@ public class UserDialogFragment extends AppCompatDialogFragment {
         builder.setView(rootView);
         AlertDialog dialog = builder.create();
 
-        RequestQueue queue = Volley.newRequestQueue(requireContext(), new VolleyOkHttp3StackInterceptors());
+        RequestQueue queue = NetworkComponent.getRequestQueueInstance(requireContext());
 
         nameTextview = rootView.findViewById(R.id.user_name);
         metaTextview = rootView.findViewById(R.id.user_meta);

--- a/app/src/main/java/com/simon/harmonichackernews/network/NetworkComponent.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/NetworkComponent.java
@@ -1,13 +1,19 @@
 package com.simon.harmonichackernews.network;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Looper;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.Volley;
 import com.simon.harmonichackernews.BuildConfig;
 
+import java.io.IOException;
+
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 public class NetworkComponent {
     private static volatile OkHttpClient okHttpClientInstance;
@@ -17,7 +23,20 @@ public class NetworkComponent {
         if (okHttpClientInstance == null) {
             synchronized (NetworkComponent.class) {
                 if (okHttpClientInstance == null) {
-                    okHttpClientInstance = new OkHttpClient();
+                    Interceptor userAgentInterceptor = new Interceptor() {
+                        @Override
+                        public Response intercept(Chain chain) throws IOException {
+                            Request originalRequest = chain.request();
+                            Request requestWithUserAgent = originalRequest.newBuilder()
+                                    .header("User-Agent", "Harmonic-HN-Android/" + BuildConfig.VERSION_NAME + "/" + BuildConfig.BUILD_TYPE)
+                                    .build();
+                            return chain.proceed(requestWithUserAgent);
+                        }
+                    };
+
+                    okHttpClientInstance = new OkHttpClient.Builder()
+                            .addInterceptor(userAgentInterceptor)
+                            .build();
                 }
             }
         }

--- a/app/src/main/java/com/simon/harmonichackernews/network/NetworkComponent.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/NetworkComponent.java
@@ -1,0 +1,38 @@
+package com.simon.harmonichackernews.network;
+
+import android.content.Context;
+import android.os.Looper;
+
+import com.android.volley.RequestQueue;
+import com.android.volley.toolbox.Volley;
+import com.simon.harmonichackernews.BuildConfig;
+
+import okhttp3.OkHttpClient;
+
+public class NetworkComponent {
+    private static volatile OkHttpClient okHttpClientInstance;
+    private static RequestQueue requestQueueInstance;
+
+    public static OkHttpClient getOkHttpClientInstance() {
+        if (okHttpClientInstance == null) {
+            synchronized (NetworkComponent.class) {
+                if (okHttpClientInstance == null) {
+                    okHttpClientInstance = new OkHttpClient();
+                }
+            }
+        }
+        return okHttpClientInstance;
+    }
+
+    public static RequestQueue getRequestQueueInstance(Context context) {
+        if (BuildConfig.DEBUG && !Looper.getMainLooper().isCurrentThread()) {
+            throw new IllegalStateException("getRequestQueueInstance currently doesn't support multithreaded access");
+        }
+
+        if (requestQueueInstance == null) {
+            requestQueueInstance = Volley.newRequestQueue(context.getApplicationContext(),
+                    new VolleyOkHttp3StackInterceptors());
+        }
+        return requestQueueInstance;
+    }
+}

--- a/app/src/main/java/com/simon/harmonichackernews/network/UserActions.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/UserActions.java
@@ -153,7 +153,7 @@ private static final String HEADER_SET_COOKIE = "set-cookie";
     }
 
     public static void executeRequest(Context ctx, Request request, ActionCallback cb) {
-        OkHttpClient client = new OkHttpClient();
+        OkHttpClient client = NetworkComponent.getOkHttpClientInstance();
 
         client.newCall(request).enqueue(new Callback() {
             final Handler mainHandler = new Handler(ctx.getMainLooper());

--- a/app/src/main/java/com/simon/harmonichackernews/network/VolleyOkHttp3StackInterceptors.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/VolleyOkHttp3StackInterceptors.java
@@ -78,7 +78,7 @@ public class VolleyOkHttp3StackInterceptors extends BaseHttpStack {
 
     @Override
     public HttpResponse executeRequest(Request<?> request, Map<String, String> additionalHeaders) throws IOException, AuthFailureError {
-        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+        OkHttpClient.Builder clientBuilder = NetworkComponent.getOkHttpClientInstance().newBuilder();
         int timeoutMs = request.getTimeoutMs();
 
         clientBuilder.connectTimeout(timeoutMs, TimeUnit.MILLISECONDS);

--- a/app/src/main/java/com/simon/harmonichackernews/network/VolleyOkHttp3StackInterceptors.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/VolleyOkHttp3StackInterceptors.java
@@ -24,6 +24,8 @@ import okhttp3.ResponseBody;
 
 public class VolleyOkHttp3StackInterceptors extends BaseHttpStack {
 
+    private static final RequestBody EMPTY_REQUEST = RequestBody.create(new byte[0]);
+
     public VolleyOkHttp3StackInterceptors() {
 
     }
@@ -36,7 +38,7 @@ public class VolleyOkHttp3StackInterceptors extends BaseHttpStack {
                 // Ensure backwards compatibility.  Volley assumes a request with a null body is a GET.
                 byte[] postBody = request.getBody();
                 if (postBody != null) {
-                    builder.post(RequestBody.create(MediaType.parse(request.getBodyContentType()), postBody));
+                    builder.post(RequestBody.create(postBody, MediaType.parse(request.getBodyContentType())));
                 }
                 break;
             case Request.Method.GET:
@@ -68,12 +70,14 @@ public class VolleyOkHttp3StackInterceptors extends BaseHttpStack {
         }
     }
 
-    private static RequestBody createRequestBody(Request r) throws AuthFailureError {
+    private static RequestBody createRequestBody(Request<?> r) throws AuthFailureError {
         final byte[] body = r.getBody();
         if (body == null) {
-            return null;
+            // For POST, PUT and PATCH requests Volley's HurlStack doesn't add body when it's null.
+            // However OkHttp requires non-null RequestBody for those methods, so use an empty body.
+            return EMPTY_REQUEST;
         }
-        return RequestBody.create(MediaType.parse(r.getBodyContentType()), body);
+        return RequestBody.create(body, MediaType.parse(r.getBodyContentType()));
     }
 
     @Override
@@ -89,11 +93,11 @@ public class VolleyOkHttp3StackInterceptors extends BaseHttpStack {
         okHttpRequestBuilder.url(request.getUrl());
 
         Map<String, String> headers = request.getHeaders();
-        for (final String name : headers.keySet()) {
-            okHttpRequestBuilder.addHeader(name, headers.get(name));
+        for (Map.Entry<String, String> header: headers.entrySet()) {
+            okHttpRequestBuilder.addHeader(header.getKey(), header.getValue());
         }
-        for (final String name : additionalHeaders.keySet()) {
-            okHttpRequestBuilder.addHeader(name, additionalHeaders.get(name));
+        for (Map.Entry<String, String> header: additionalHeaders.entrySet()) {
+            okHttpRequestBuilder.addHeader(header.getKey(), header.getValue());
         }
 
         setConnectionParametersForRequest(okHttpRequestBuilder, request);
@@ -101,6 +105,11 @@ public class VolleyOkHttp3StackInterceptors extends BaseHttpStack {
         OkHttpClient client = clientBuilder.build();
         okhttp3.Request okHttpRequest = okHttpRequestBuilder.build();
         Call okHttpCall = client.newCall(okHttpRequest);
+        // todo: close response. Note that it is not as simple as adding try-with-resources because
+        //  that would close the response before Volley has had a chance to consume it. At the same
+        //  time, not closing the response is also wrong because it will not be closed at all.
+        //  Volley closes only input stream created from response body's which is not the same as
+        //  closing the response.
         Response okHttpResponse = okHttpCall.execute();
 
 
@@ -116,9 +125,7 @@ public class VolleyOkHttp3StackInterceptors extends BaseHttpStack {
         List<Header> headers = new ArrayList<>();
         for (int i = 0, len = responseHeaders.size(); i < len; i++) {
             final String name = responseHeaders.name(i), value = responseHeaders.value(i);
-            if (name != null) {
-                headers.add(new Header(name, value));
-            }
+            headers.add(new Header(name, value));
         }
         return headers;
     }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ArchiveOrgUrlGetter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ArchiveOrgUrlGetter.java
@@ -4,9 +4,8 @@ import android.content.Context;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.StringRequest;
-import com.android.volley.toolbox.Volley;
 
-import com.simon.harmonichackernews.network.VolleyOkHttp3StackInterceptors;
+import com.simon.harmonichackernews.network.NetworkComponent;
 
 import org.json.JSONObject;
 
@@ -38,7 +37,7 @@ public class ArchiveOrgUrlGetter {
 
         });
 
-        RequestQueue queue = Volley.newRequestQueue(ctx, new VolleyOkHttp3StackInterceptors());
+        RequestQueue queue = NetworkComponent.getRequestQueueInstance(ctx);
         queue.add(stringRequest);
 
     }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/FileDownloader.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/FileDownloader.java
@@ -8,12 +8,13 @@ import android.text.TextUtils;
 
 import androidx.annotation.WorkerThread;
 
+import com.simon.harmonichackernews.network.NetworkComponent;
+
 import java.io.File;
 import java.io.IOException;
 
 import okhttp3.Call;
 import okhttp3.Callback;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okio.BufferedSink;
@@ -53,7 +54,7 @@ public class FileDownloader {
                 .addHeader("Content-Type", mimeType)
                 .build();
 
-        new OkHttpClient().newCall(request).enqueue(new Callback() {
+        NetworkComponent.getOkHttpClientInstance().newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
                 mMainHandler.post(() -> callback.onFailure(call, e));


### PR DESCRIPTION
Using singletons as recommended by [OkHttp](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#okhttpclients-should-be-shared) and [Volley](https://google.github.io/volley/requestqueue.html#use-a-singleton-pattern).

Also cleaned up most of the warnings in `VolleyOkHttp3StackInterceptors`.
