### PR TITLE
Use onDestroyView fragment methods for cleanup

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -909,15 +909,6 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
         }
     }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        if (queue != null) {
-            queue.cancelAll(requestTag);
-        }
-        destroyWebView();
-    }
-
     public void destroyWebView() {
         //nuclear
         webViewContainer.removeAllViews();
@@ -948,6 +939,11 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
         }
 
         super.onDestroyView();
+
+        if (queue != null) {
+            queue.cancelAll(requestTag);
+        }
+        destroyWebView();
     }
 
     public void refreshComments() {

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -392,8 +392,8 @@ public class StoriesFragment extends Fragment {
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
+    public void onDestroyView() {
+        super.onDestroyView();
         if (queue != null) {
             queue.cancelAll(requestTag);
         }


### PR DESCRIPTION
This addresses two problems.

The first one is a rare crash in CommentsFragment that can happen if
fragment gets destroyed after executing onCreate but before
onViewCreated. In this case webView is null which causes
NullPointerException.

The second one is a memory leak that can happen if fragment's view is
destroyed, but fragment itself is not. In this case requests will still
hold references to the layout in their listeners but the layout is
supposed to be free for garbage collection at this point. Note that
technically this doesn't change anything because the fragment itself
still holds references to the views. Still, this code is less wrong
than the old version.
