### PR TITLE
New comment transition

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:targetApi="tiramisu">
         <property
           android:name="android.window.PROPERTY_ACTIVITY_EMBEDDING_SPLITS_ENABLED"
           android:value="true" />
@@ -35,15 +36,14 @@
             android:configChanges="orientation|screenSize"/>
         <activity
             android:name=".AboutActivity"
-            android:enableOnBackInvokedCallback="true"
-            android:configChanges="orientation|screenSize"
-            tools:targetApi="tiramisu" />
+            android:configChanges="orientation|screenSize" />
         <activity
             android:name=".ComposeActivity"
             android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|screenSize"/>
         <activity
             android:name=".CommentsActivity"
+            android:theme="@style/CommentsDefaultTheme"
             android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter android:label="@string/app_name">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,6 @@
         <activity
             android:name=".CommentsActivity"
             android:configChanges="orientation|screenSize"
-            android:theme="@style/Theme.Swipe.Back.NoActionBar"
             android:exported="true">
             <intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/com/simon/harmonichackernews/CommentsActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsActivity.java
@@ -26,7 +26,7 @@ public class CommentsActivity extends AppCompatActivity implements CommentsFragm
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        ThemeUtils.setupTheme(this, true);
+        ThemeUtils.setupTheme(this, !SettingsUtils.shouldDisableCommentsSwipeBack(getApplicationContext()));
 
         setContentView(R.layout.activity_comments);
 

--- a/app/src/main/java/com/simon/harmonichackernews/MainActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/MainActivity.java
@@ -100,7 +100,7 @@ public class MainActivity extends AppCompatActivity implements StoriesFragment.S
             startActivity(intent);
 
             if (!SettingsUtils.shouldDisableCommentsSwipeBack(getApplicationContext())) {
-                overridePendingTransition(R.anim.activity_in_animation, 0);
+                overridePendingTransition(R.anim.activity_in_animation, R.anim.hold);
             }
         }
     }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
@@ -70,10 +70,12 @@ public class ThemeUtils {
             case "white":
                 activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBarWhite : R.style.AppThemeWhite);
                 break;
-            //needed because of comment activity where the default is apptheme
+            //needed because of comment activity where the default is apptheme, now swipeback
             case "dark":
+                Utils.toast(swipeBack ? "sw" : "no", activity);
                 activity.setTheme(swipeBack ? R.style.Theme_Swipe_Back_NoActionBar : R.style.AppTheme);
                 break;
+
         }
 
         Window window = activity.getWindow();
@@ -85,9 +87,16 @@ public class ThemeUtils {
             WindowCompat.setDecorFitsSystemWindows(window, false);
         }
 
-        if (swipeBack) {
-            window.setFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS, WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        /*this is a long story. On CommentsActivity, the default theme is dependent on the android version.
+            For 24-29, we set SwipeBack as the defaul theme and do nothing more
+            For 30-33, we set AppTheme as the default and perhaps switch to SwipeBack if the user wants to, but in that case we indicate translucency manually
+            which makes it so that SwipeBack can peek to MainActivity
+            For 34+, translucent = true is set automatically in the onResume (after a delay) which makes the peek work
+
+            On a somewhat related note, transparent status bar messes the intended MainActivity -> CommentsActivity transition up sadly...
+        * */
+        if (swipeBack && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            activity.setTranslucent(true);
         }
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.view.Window;
+import android.view.WindowManager;
 
 import androidx.activity.ComponentActivity;
 import androidx.activity.EdgeToEdge;
@@ -68,6 +70,10 @@ public class ThemeUtils {
             case "white":
                 activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBarWhite : R.style.AppThemeWhite);
                 break;
+            //needed because of comment activity where the default is apptheme
+            case "dark":
+                activity.setTheme(swipeBack ? R.style.Theme_Swipe_Back_NoActionBar : R.style.AppTheme);
+                break;
         }
 
         Window window = activity.getWindow();
@@ -77,6 +83,11 @@ public class ThemeUtils {
 
         if (specialFlags) {
             WindowCompat.setDecorFitsSystemWindows(window, false);
+        }
+
+        if (swipeBack) {
+            window.setFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS, WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         }
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {

--- a/app/src/main/res/anim/hold.xml
+++ b/app/src/main/res/anim/hold.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+        android:duration="400"
+        android:fromAlpha="1.0"
+        android:toAlpha="1.0" />
+</set>

--- a/app/src/main/res/values-v30/styles.xml
+++ b/app/src/main/res/values-v30/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="CommentsDefaultTheme" parent="AppTheme"/>
+
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -189,4 +189,6 @@
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 
+    <style name="CommentsDefaultTheme" parent="Theme.Swipe.Back.NoActionBar"/>
+
 </resources>


### PR DESCRIPTION
Quite a lot of logic here. The idea is to use the default activity transition when starting the comments screen. Previously, we could not do this because the CommentsActivity had a bunch of weird styling (due to SwipeBack). When SwipeBack is active, nothing is changed this way.

First of all, the default theme for CommentsActivity is now AppTheme as this is seemingly required to get the animation to play. Then ThemeUtils may change the theme. For API < 30, we keep SwipeBack as the default theme and don't true to change anything.

For API >= 30, we need to set translucency of the activity to true to enable SwipeBack peeking so this is done. We only do this is SwipeBack is active though because this messes up the animation otherwise. Somewhat surprisingly, on API >= 34, translucency to true is fine, I guess because things have been reworked to help with Predictive Back .

