### PR TITLE
Revert search sorting behaviour.

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -666,7 +666,7 @@ public class StoriesFragment extends Fragment {
         lastSearch = query;
         adapter.lastSearch = query;
 
-        loadAlgolia("https://hn.algolia.com/api/v1/search?query=" + query + "&tags=story&hitsPerPage=200", false);
+        loadAlgolia("https://hn.algolia.com/api/v1/search_by_date?query=" + query + "&tags=story&hitsPerPage=200", false);
     }
 
     private void loadAlgolia(String url, boolean markClicked) {


### PR DESCRIPTION
Per the tin.

It looks like the regression was introduced in https://github.com/SimonHalvdansson/Harmonic-HN/commit/67837bb50f04cf20f12548b73478169ee9fa3609, which modified the search API endpoint here:

https://github.com/SimonHalvdansson/Harmonic-HN/blob/259a36f11474687145f2a984c9b0d82087fcc9ee/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java#L653-L660

`relevance` was always false, so the API endpoint always resolved to `/api/v1/search_by_date/...`.

Closes https://github.com/SimonHalvdansson/Harmonic-HN/issues/115