### PR TITLE
Fix user submissions failing to load.

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/network/JSONParser.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/JSONParser.java
@@ -30,7 +30,10 @@ public class JSONParser {
             JSONObject hit = hits.getJSONObject(i);
 
             Story story = new Story();
-            story.title = hit.getString("title");
+
+            boolean isComment = hit.getJSONArray("_tags").get(0).equals("comment");
+
+            story.title = isComment ? hit.getString("story_title") : hit.getString("title");
             story.score = hit.optInt("points");
             story.by = hit.getString("author");
             story.descendants = hit.optInt("num_comments");
@@ -52,12 +55,12 @@ public class JSONParser {
                 story.text = hit.getString("story_text");
             }
 
-            if (hit.getJSONArray("_tags").get(0).equals("comment")) {
+            if (isComment) {
                 story.isComment = true;
                 story.text = hit.getString("comment_text");
                 story.commentMasterTitle = hit.getString("story_title");
                 story.commentMasterId = hit.getInt("story_id");
-                if (!hit.getString("story_url").equals("null")) {
+                if (hit.has("story_url") && !hit.getString("story_url").equals("null")) {
                     story.commentMasterUrl = hit.getString("story_url");
                     story.isLink = true;
                 } else {


### PR DESCRIPTION
I noticed this while poking around the different layouts, but this page doesn't seem to work. Perhaps Algolia's schema has changed, but `.hits[].title` isn't guranteed to exist anymore -- it seems that comment hits now return `story_title` instead. 

While testing, I also noticed that `story_url` doesn't always exist, even if the hit is a comment. For instance:

```bash
curl https://hn.algolia.com/api/v1/search_by_date?tags=author_pg&hitsPerPage=999 | jq '.hits[] | select(._tags[0] == "comment") | has("story_url")'
```

Doesn't always return true 😞 

This PR basically fixes the two issues above. I also considered wrapping this loop in a try-catch block, but wasn't sure if you'd prefer to fail closed on any parsing issues (perhaps no results is better than partial but missing results?). I'm open to feedback here though.



### Before

https://github.com/SimonHalvdansson/Harmonic-HN/assets/3242609/d1eb9685-3ffb-447a-9722-67e6a988199a

### After

https://github.com/SimonHalvdansson/Harmonic-HN/assets/3242609/45642f7c-a9fc-4b2c-ab2f-43ee0d8082ab
