### PR TITLE
Feat: Add option to hide comments count in list view

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
@@ -110,6 +110,7 @@ public class SettingsActivity extends AppCompatActivity {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
                     changePrefStatus(findPreference("pref_show_points"), !(boolean) newValue);
+                    changePrefStatus(findPreference("pref_show_comments_count"), !(boolean) newValue);
                     changePrefStatus(findPreference("pref_thumbnails"), !(boolean) newValue);
 
                     return true;
@@ -130,8 +131,8 @@ public class SettingsActivity extends AppCompatActivity {
             boolean compact = SettingsUtils.shouldUseCompactView(getContext());
 
             changePrefStatus(findPreference("pref_show_points"), !compact);
+            changePrefStatus(findPreference("pref_show_comments_count"), !compact);
             changePrefStatus(findPreference("pref_thumbnails"), !compact);
-
 
             findPreference("pref_transparent_status_bar").setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -196,6 +196,7 @@ public class StoriesFragment extends Fragment {
     private void setupAdapter() {
         adapter = new StoryRecyclerViewAdapter(stories,
                 SettingsUtils.shouldShowPoints(getContext()),
+                SettingsUtils.shouldShowCommentsCount(getContext()),
                 SettingsUtils.shouldUseCompactView(getContext()),
                 SettingsUtils.shouldShowThumbnails(getContext()),
                 SettingsUtils.shouldShowIndex(getContext()),
@@ -348,6 +349,11 @@ public class StoriesFragment extends Fragment {
 
         if (adapter.showPoints != SettingsUtils.shouldShowPoints(getContext())) {
             adapter.showPoints = !adapter.showPoints;
+            adapter.notifyItemRangeChanged(1, stories.size());
+        }
+
+        if (adapter.showCommentsCount != SettingsUtils.shouldShowCommentsCount(getContext())) {
+            adapter.showCommentsCount = !adapter.showCommentsCount;
             adapter.notifyItemRangeChanged(1, stories.size());
         }
 

--- a/app/src/main/java/com/simon/harmonichackernews/SubmissionsActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/SubmissionsActivity.java
@@ -65,6 +65,7 @@ public class SubmissionsActivity extends AppCompatActivity {
 
         adapter = new StoryRecyclerViewAdapter(submissions,
                 SettingsUtils.shouldShowPoints(this),
+                SettingsUtils.shouldShowCommentsCount(this),
                 SettingsUtils.shouldUseCompactView(this),
                 SettingsUtils.shouldShowThumbnails(this),
                 false,

--- a/app/src/main/java/com/simon/harmonichackernews/adapters/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/adapters/StoryRecyclerViewAdapter.java
@@ -80,6 +80,7 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
     public boolean loadingFailedServerError = false;
 
     public boolean showPoints;
+    public boolean showCommentsCount;
     public boolean compactView;
     public boolean thumbnails;
     public boolean showIndex;
@@ -94,6 +95,7 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
 
     public StoryRecyclerViewAdapter(List<Story> items,
                                     boolean shouldShowPoints,
+                                    boolean shouldShowCommentsCount,
                                     boolean shouldUseCompactView,
                                     boolean shouldShowThumbnails,
                                     boolean shouldShowIndex,
@@ -105,6 +107,7 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
                                     int wantedType) {
         stories = items;
         showPoints = shouldShowPoints;
+        showCommentsCount = shouldShowCommentsCount;
         compactView = shouldUseCompactView;
         thumbnails = shouldShowThumbnails;
         showIndex = shouldShowIndex;
@@ -172,7 +175,16 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
                     storyViewHolder.titleView.setText(storyViewHolder.story.title);
                 }
 
-                storyViewHolder.commentsView.setText(Integer.toString(storyViewHolder.story.descendants));
+                final String commentCountText;
+                if (showCommentsCount) {
+                    commentCountText = Integer.toString(storyViewHolder.story.descendants);
+                } else if (storyViewHolder.story.descendants > 0){
+                    commentCountText = "•";
+                } else {
+                    commentCountText = "";
+                }
+                storyViewHolder.commentsView.setText(commentCountText);
+
                 String host = "";
 
                 try {

--- a/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
@@ -72,6 +72,10 @@ public class SettingsUtils {
         return getBooleanPref("pref_show_points", true, ctx);
     }
 
+    public static boolean shouldShowCommentsCount(Context ctx) {
+        return getBooleanPref("pref_show_comments_count", true, ctx);
+    }
+
     public static boolean shouldUseCompactView(Context ctx) {
         return getBooleanPref("pref_compact_view", false, ctx);
     }

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -81,7 +81,7 @@
             app:key="pref_show_comments_count"
             app:defaultValue="true"
             app:icon="@drawable/ic_action_comment"
-            app:title="Show comments count"    />
+            app:title="Show comment count"    />
 
         <SwitchPreferenceCompat
             app:singleLineTitle="false"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -78,6 +78,13 @@
 
         <SwitchPreferenceCompat
             app:singleLineTitle="false"
+            app:key="pref_show_comments_count"
+            app:defaultValue="true"
+            app:icon="@drawable/ic_action_comment"
+            app:title="Show comments count"    />
+
+        <SwitchPreferenceCompat
+            app:singleLineTitle="false"
             app:key="pref_show_index"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_index"


### PR DESCRIPTION
## Description

This comment adds a feature to hide the number of comments of a story in the list view. It replaces the number of comments with a dot if there is any, or nothing if there is no comment.

Option is disabled by default (comments count is displayed), and does not show-up during initial setup.

## Motivation

This allows a more zen approach to browsing for interesting stories. This toggle+hide story points prevents appeal to popularity while selecting a story to read.  

## Testing:
* Tested loading the app without any setting change
* Tested changing setting, going back to list view, restarting app
* Checked: setting unset, story with no comments, stories with >0 comments
* Loaded Hot Stories page and New Stories page

## Screenshots

| Hot Stories | New Stories | Setting page |
| ----------- | ------------ | ------|
| ![Screenshot_20231119_180920_Harmonic](https://github.com/SimonHalvdansson/Harmonic-HN/assets/1964358/f82cd507-6a2a-4d1b-b532-dd41d9d566e6) | ![Screenshot_20231119_180911_Harmonic](https://github.com/SimonHalvdansson/Harmonic-HN/assets/1964358/39f5106d-2104-4e45-9536-f9b766543a16) | ![Screenshot_20231119_181001_Harmonic](https://github.com/SimonHalvdansson/Harmonic-HN/assets/1964358/b7b9e0e3-5ad9-4887-8255-dbd7d6bd8dee) |

