### PR TITLE
Issue rendering code blocks where words would break unexpetedly

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/adapters/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/adapters/StoryRecyclerViewAdapter.java
@@ -500,12 +500,11 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
 
         public final TextView headerText;
         public final HtmlTextView bodyText;
-        public final MaterialButton storyButton;
-        public final MaterialButton repliesButton;
+        public final Button storyButton;
+        public final Button repliesButton;
         public final View scrim;
 
 
-        @SuppressLint("WrongViewCast")
         public CommentViewHolder(View view) {
             super(view);
             headerText = view.findViewById(R.id.submissions_comment_header);

--- a/app/src/main/java/com/simon/harmonichackernews/adapters/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/adapters/StoryRecyclerViewAdapter.java
@@ -504,6 +504,8 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
         public final MaterialButton repliesButton;
         public final View scrim;
 
+
+        @SuppressLint("WrongViewCast")
         public CommentViewHolder(View view) {
             super(view);
             headerText = view.findViewById(R.id.submissions_comment_header);

--- a/app/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatter.java
+++ b/app/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatter.java
@@ -16,6 +16,7 @@ package org.sufficientlysecure.htmltextview;
 
 import android.text.Html;
 import android.text.Html.ImageGetter;
+import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 
 import androidx.annotation.NonNull;
@@ -58,7 +59,11 @@ public class HtmlFormatter {
             formattedHtml = Html.fromHtml(html, imageGetter, new WrapperContentHandler(htmlTagHandler));
         }
 
-        return formattedHtml;
+        // Replace non breaking spaces with breaking spaces.
+        // They make unexpected line-breaks even in the middle of a word.
+        SpannableStringBuilder builder = new SpannableStringBuilder(formattedHtml);
+        replaceNonBreakingSpaces(builder);
+        return (Spanned) builder.subSequence(0, builder.length());
     }
 
     /**
@@ -76,5 +81,18 @@ public class HtmlFormatter {
             text = (Spanned) text.subSequence(0, text.length() - 1);
         }
         return text;
+    }
+
+    private static void replaceNonBreakingSpaces(SpannableStringBuilder builder) {
+        int start = 0;
+        while (start < builder.length()) {
+            int index = builder.toString().indexOf('\u00A0', start);
+            if (index != -1) {
+                builder.replace(index, index + 1, " ");
+                start = index + 1;
+            } else {
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
`Html.fromHtml()` formats code blocks by inserting non-breaking spaces, `\u00A0`. This made words break unexpectedly since the entire line is considered a single word. 

The old behavior was to fit as much as possible on one line, then jump to the next, disregarding word boundaries, which is much harder to read.
This reverts non-breaking spaces to regular spaces.