### PR TITLE
Close #135, Filter stories less than x points

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
@@ -321,7 +321,7 @@ public class SettingsActivity extends AppCompatActivity {
             int[] nighttimeHours = Utils.getNighttimeHours(getContext());
 
             if (DateFormat.is24HourFormat(getContext())) {
-                findPreference("pref_theme_timed_range").setSummary((nighttimeHours[0] < 10 ? "0" : "") + nighttimeHours[0] + ":" + (nighttimeHours[1] < 10 ? "0" : "") +  nighttimeHours[1] + " - " + (nighttimeHours[2] < 10 ? "0" : "") + nighttimeHours[2] + ":" + (nighttimeHours[3] < 10 ? "0" : "") + nighttimeHours[3]);
+                findPreference("pref_theme_timed_range").setSummary((nighttimeHours[0] < 10 ? "0" : "") + nighttimeHours[0] + ":" + (nighttimeHours[1] < 10 ? "0" : "") + nighttimeHours[1] + " - " + (nighttimeHours[2] < 10 ? "0" : "") + nighttimeHours[2] + ":" + (nighttimeHours[3] < 10 ? "0" : "") + nighttimeHours[3]);
 
             } else {
                 SimpleDateFormat df = new SimpleDateFormat("h:mm a");

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -5,10 +5,8 @@ import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -73,6 +71,7 @@ public class StoriesFragment extends Fragment {
     private LinearLayoutManager linearLayoutManager;
     private Set<Integer> clickedIds;
     private ArrayList<String> filterWords;
+    private int minimumScore;
     private boolean hideJobs, alwaysOpenComments, hideClicked;
     private String lastSearch;
 
@@ -336,6 +335,7 @@ public class StoriesFragment extends Fragment {
         super.onResume();
 
         filterWords = Utils.getFilterWords(getContext());
+        minimumScore = Utils.getMinScore(getContext());
         hideJobs = SettingsUtils.shouldHideJobs(getContext());
         hideClicked = SettingsUtils.shouldHideClicked(getContext());
         alwaysOpenComments = SettingsUtils.shouldAlwaysOpenComments(getContext());
@@ -474,6 +474,14 @@ public class StoriesFragment extends Fragment {
 
                         //or because it's a job
                         if (hideJobs && adapter.type != SettingsUtils.getJobsIndex(getResources()) && (story.isJob || story.by.equals("whoishiring"))) {
+                            stories.remove(story);
+                            adapter.notifyItemRemoved(index);
+                            loadedTo = Math.max(0, loadedTo - 1);
+                            return;
+                        }
+
+                        //or because it's less than the minimum score
+                        if (story.score < minimumScore) {
                             stories.remove(story);
                             adapter.notifyItemRemoved(index);
                             loadedTo = Math.max(0, loadedTo - 1);

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -481,7 +481,7 @@ public class StoriesFragment extends Fragment {
                         }
 
                         //or because it's less than the minimum score
-                        if (adapter.type == SettingsUtils.getTopStoriesIndex(getResources()) && story.score < minimumScore) {
+                        if (story.score < minimumScore) {
                             stories.remove(story);
                             adapter.notifyItemRemoved(index);
                             loadedTo = Math.max(0, loadedTo - 1);
@@ -682,7 +682,7 @@ public class StoriesFragment extends Fragment {
     }
 
     private void loadTopStoriesSince(int start_i) {
-        loadAlgolia("https://hn.algolia.com/api/v1/search?tags=story&numericFilters=created_at_i>" + start_i + "&hitsPerPage=200", true);
+        loadAlgolia("https://hn.algolia.com/api/v1/search?tags=story&numericFilters=points>=" + minimumScore +",created_at_i>" + start_i + "&hitsPerPage=200", true);
     }
 
     private void search(String query) {

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -481,7 +481,7 @@ public class StoriesFragment extends Fragment {
                         }
 
                         //or because it's less than the minimum score
-                        if (story.score < minimumScore) {
+                        if (adapter.type == SettingsUtils.getTopStoriesIndex(getResources()) && story.score < minimumScore) {
                             stories.remove(story);
                             adapter.notifyItemRemoved(index);
                             loadedTo = Math.max(0, loadedTo - 1);

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -205,7 +205,7 @@ public class StoriesFragment extends Fragment {
                 SettingsUtils.getPreferredFaviconProvider(getContext()),
                 null,
                 getPreferredTypeIndex()
-                );
+        );
 
         adapter.setOnLinkClickListener(position -> {
             if (position == RecyclerView.NO_POSITION) {
@@ -309,7 +309,7 @@ public class StoriesFragment extends Fragment {
                     //the reason for the -10 - height/3 thing is so match the popup location better
                     //with the press location - for some reason this is necessary.
                     int targetX = x - Utils.pxFromDpInt(getResources(), 56);
-                    int targetY = y - topInset - Utils.pxFromDpInt(getResources(), 10) - v.getHeight()/3;
+                    int targetY = y - topInset - Utils.pxFromDpInt(getResources(), 10) - v.getHeight() / 3;
 
                     menuPopupHelper.getClass().getDeclaredMethod("show", int.class, int.class).invoke(menuPopupHelper, targetX, targetY);
                 } catch (Exception e) {
@@ -343,7 +343,7 @@ public class StoriesFragment extends Fragment {
         long timeDiff = System.currentTimeMillis() - lastLoaded;
 
         // if more than 1 hr
-        if (timeDiff > 1000*60*60 && !adapter.searching && adapter.type != SettingsUtils.getBookmarksIndex(getResources()) && !currentTypeIsAlgolia()) {
+        if (timeDiff > 1000 * 60 * 60 && !adapter.searching && adapter.type != SettingsUtils.getBookmarksIndex(getResources()) && !currentTypeIsAlgolia()) {
             showUpdateButton();
         }
 
@@ -559,11 +559,11 @@ public class StoriesFragment extends Fragment {
             int currentTime = (int) (System.currentTimeMillis() / 1000);
             int startTime = currentTime;
             if (adapter.type == 1) {
-                startTime = currentTime - 60*60*24;
+                startTime = currentTime - 60 * 60 * 24;
             } else if (adapter.type == 2) {
-                startTime = currentTime - 60*60*48;
+                startTime = currentTime - 60 * 60 * 48;
             } else if (adapter.type == 3) {
-                startTime = currentTime - 60*60*24*7;
+                startTime = currentTime - 60 * 60 * 24 * 7;
             }
 
             loadTopStoriesSince(startTime);

--- a/app/src/main/java/com/simon/harmonichackernews/network/NetworkComponent.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/NetworkComponent.java
@@ -1,14 +1,12 @@
 package com.simon.harmonichackernews.network;
 
 import android.content.Context;
-import android.os.Build;
 import android.os.Looper;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.Volley;
 import com.simon.harmonichackernews.BuildConfig;
-import com.simon.harmonichackernews.data.ArxivInfo;
-import com.simon.harmonichackernews.data.RepoInfo;
+
 
 import java.io.IOException;
 

--- a/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
@@ -224,6 +224,7 @@ public class SettingsUtils {
     public static int getPreferredCommentTextSize(Context ctx) {
         return Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(ctx).getString("pref_comment_text_size", "15"));
     }
+
     public static String getPreferredStoryType(Context ctx) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
         return prefs.getString("pref_default_story_type", "Top Stories");
@@ -240,7 +241,7 @@ public class SettingsUtils {
     }
 
     public static int getBookmarksIndex(Resources res) {
-        String[] sortingOptions =  res.getStringArray(R.array.sorting_options);
+        String[] sortingOptions = res.getStringArray(R.array.sorting_options);
 
         for (int i = sortingOptions.length - 1; i >= 0; i--) {
             if (sortingOptions[i].equals("Bookmarks")) {
@@ -252,7 +253,7 @@ public class SettingsUtils {
     }
 
     public static int getJobsIndex(Resources res) {
-        String[] sortingOptions =  res.getStringArray(R.array.sorting_options);
+        String[] sortingOptions = res.getStringArray(R.array.sorting_options);
 
         for (int i = sortingOptions.length - 1; i >= 0; i--) {
             if (sortingOptions[i].equals("HN Jobs")) {

--- a/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
@@ -264,16 +264,4 @@ public class SettingsUtils {
         //fallback
         return sortingOptions.length - 2;
     }
-    public static int getTopStoriesIndex(@NonNull Resources res) {
-        String[] sortingOptions = res.getStringArray(R.array.sorting_options);
-
-        for (int i = sortingOptions.length - 1; i >= 0; i--) {
-            if (sortingOptions[i].equals("Top Stories")) {
-                return i;
-            }
-        }
-        //fallback
-        return 0;
-    }
-
 }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 
+import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 
 import com.simon.harmonichackernews.R;
@@ -262,6 +263,17 @@ public class SettingsUtils {
         }
         //fallback
         return sortingOptions.length - 2;
+    }
+    public static int getTopStoriesIndex(@NonNull Resources res) {
+        String[] sortingOptions = res.getStringArray(R.array.sorting_options);
+
+        for (int i = sortingOptions.length - 1; i >= 0; i--) {
+            if (sortingOptions[i].equals("Top Stories")) {
+                return i;
+            }
+        }
+        //fallback
+        return 0;
     }
 
 }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
@@ -22,10 +22,7 @@ import android.widget.Toast;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.content.ContextCompat;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.simon.harmonichackernews.BuildConfig;
 import com.simon.harmonichackernews.CommentsActivity;
@@ -293,6 +290,17 @@ public class Utils {
             }
         }
         return phrases;
+    }
+    public static int getMinScore(Context ctx) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
+        String prefText = prefs.getString("pref_filter_score", null);
+        int minScore;
+        try{
+            minScore = Integer.parseInt(prefText);
+        } catch (Exception e){
+            minScore = 0;
+        }
+        return minScore;
     }
 
     public static boolean isFirstAppStart(Context ctx) {

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
@@ -109,7 +109,7 @@ public class Utils {
 
     public static String getDomainName(String url) throws Exception {
         if (url.endsWith("#")) {
-            url = url.substring(0, url.length()-1);
+            url = url.substring(0, url.length() - 1);
         }
         URI uri = new URI(url);
         String domain = uri.getHost();
@@ -151,7 +151,7 @@ public class Utils {
         }
         //if there already exists a story with the same id, remove it from list of cached since we're only saving the latest one
         if (cachedStories.size() > 0) {
-            for (Iterator<String> iterator = cachedStories.iterator(); iterator.hasNext();) {
+            for (Iterator<String> iterator = cachedStories.iterator(); iterator.hasNext(); ) {
                 String cached = iterator.next();
                 String[] idAndDate = cached.split("-");
                 if (Integer.parseInt(idAndDate[0]) == id) {
@@ -172,7 +172,7 @@ public class Utils {
                     oldestId = Integer.parseInt(idAndDate[0]);
                 }
             }
-            
+
             cachedStories.remove(oldestId + "-" + oldestTime);
 
             ctx.getSharedPreferences(GLOBAL_SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE).edit().remove(KEY_SHARED_PREFERENCES_CACHED_STORY + oldestId).apply();
@@ -291,13 +291,14 @@ public class Utils {
         }
         return phrases;
     }
+
     public static int getMinScore(Context ctx) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
         String prefText = prefs.getString("pref_filter_score", null);
         int minScore;
-        try{
+        try {
             minScore = Integer.parseInt(prefText);
-        } catch (Exception e){
+        } catch (Exception e) {
             minScore = 0;
         }
         return minScore;
@@ -490,7 +491,7 @@ public class Utils {
         return packagesSupportingCustomTabs;
     }
 
-    public static int[] JSONArrayToIntArray(JSONArray jsonArray){
+    public static int[] JSONArrayToIntArray(JSONArray jsonArray) {
         int[] intArray = new int[jsonArray.length()];
         for (int i = 0; i < intArray.length; ++i) {
             intArray[i] = jsonArray.optInt(i);
@@ -552,7 +553,7 @@ public class Utils {
 
         return initialTime <= currentTime && currentTime < finalTime;
     }
-    
+
     public static void setNighttimeHours(int fromHour, int fromMinute, int toHour, int toMinute, Context ctx) {
         SettingsUtils.saveStringToSharedPreferences(ctx, KEY_NIGHTTIME_FROM_HOUR, fromHour + "");
         SettingsUtils.saveStringToSharedPreferences(ctx, KEY_NIGHTTIME_FROM_MINUTE, fromMinute + "");
@@ -561,7 +562,7 @@ public class Utils {
     }
 
     public static int[] getNighttimeHours(Context ctx) {
-        return new int[] {
+        return new int[]{
                 Integer.parseInt(SettingsUtils.readStringFromSharedPreferences(ctx, KEY_NIGHTTIME_FROM_HOUR, "21")),
                 Integer.parseInt(SettingsUtils.readStringFromSharedPreferences(ctx, KEY_NIGHTTIME_FROM_MINUTE, "0")),
                 Integer.parseInt(SettingsUtils.readStringFromSharedPreferences(ctx, KEY_NIGHTTIME_TO_HOUR, "6")),
@@ -570,11 +571,11 @@ public class Utils {
     }
 
     public static boolean timeInSecondsMoreThanTwoWeeksAgo(int time) {
-        return (System.currentTimeMillis() - ((long) time)*1000)/1000/60/60/24 > 14;
+        return (System.currentTimeMillis() - ((long) time) * 1000) / 1000 / 60 / 60 / 24 > 14;
     }
 
     public static boolean timeInSecondsMoreThanTwoHoursAgo(int time) {
-        return (System.currentTimeMillis() - ((long) time)*1000)/1000/60/60 > 2;
+        return (System.currentTimeMillis() - ((long) time) * 1000) / 1000 / 60 / 60 > 2;
     }
 
     public static float pxFromDp(final Resources resources, final float dp) {

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -368,6 +368,7 @@
             app:summary="Hide stories based on words in title"
             app:title="Filter stories on words" />
         <EditTextPreference
+            app:dialogMessage="Setting this value too high may cause the UI to become janky."
             app:icon="@drawable/ic_action_block"
             app:key="pref_filter_score"
             app:singleLineTitle="false"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -373,7 +373,7 @@
             app:key="pref_filter_score"
             app:singleLineTitle="false"
             app:summary="Hide stories based on a minimum score"
-            app:title="Filter stories on score" />
+            app:title="Filter top stories on score" />
 
         <SwitchPreferenceCompat
             app:defaultValue="false"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,421 +1,427 @@
-<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory
-        app:title="Theme"
-        android:layout="@layout/preference_category">
+        android:layout="@layout/preference_category"
+        app:title="Theme">
 
         <ListPreference
-            app:singleLineTitle="false"
-            app:icon="@drawable/ic_action_style"
-            app:title="Theme"
-            app:key="pref_theme"
-            app:useSimpleSummaryProvider="true"
-            app:entries="@array/theme_entries"
             app:defaultValue="material_daynight"
-            app:entryValues="@array/theme_values"   />
+            app:entries="@array/theme_entries"
+            app:entryValues="@array/theme_values"
+            app:icon="@drawable/ic_action_style"
+            app:key="pref_theme"
+            app:singleLineTitle="false"
+            app:title="Theme"
+            app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_special_nighttime"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_night"
-            app:title="Special nighttime theme"    />
+            app:key="pref_special_nighttime"
+            app:singleLineTitle="false"
+            app:title="Special nighttime theme" />
 
         <Preference
             app:dependency="pref_special_nighttime"
-            app:singleLineTitle="false"
-            app:key="pref_theme_timed_range"
             app:icon="@drawable/ic_action_time"
-            app:title="Timed range"    />
+            app:key="pref_theme_timed_range"
+            app:singleLineTitle="false"
+            app:title="Timed range" />
 
         <ListPreference
-            app:dependency="pref_special_nighttime"
-            app:singleLineTitle="false"
-            app:icon="@drawable/ic_action_dark_mode"
-            app:title="Nighttime theme"
-            app:key="pref_theme_nighttime"
-            app:useSimpleSummaryProvider="true"
-            app:entries="@array/theme_entries"
             app:defaultValue="dark"
-            app:entryValues="@array/theme_values"   />
+            app:dependency="pref_special_nighttime"
+            app:entries="@array/theme_entries"
+            app:entryValues="@array/theme_values"
+            app:icon="@drawable/ic_action_dark_mode"
+            app:key="pref_theme_nighttime"
+            app:singleLineTitle="false"
+            app:title="Nighttime theme"
+            app:useSimpleSummaryProvider="true" />
 
     </PreferenceCategory>
 
     <PreferenceCategory
-        app:title="Display"
-        android:layout="@layout/preference_category">
+        android:layout="@layout/preference_category"
+        app:title="Display">
 
         <ListPreference
-            app:singleLineTitle="false"
-            app:icon="@drawable/ic_action_bookmark_border"
-            app:title="Default starting page"
-            app:key="pref_default_story_type"
-            app:useSimpleSummaryProvider="true"
-            app:entries="@array/sorting_options"
             app:defaultValue="Top Stories"
-            app:entryValues="@array/sorting_options"   />
+            app:entries="@array/sorting_options"
+            app:entryValues="@array/sorting_options"
+            app:icon="@drawable/ic_action_bookmark_border"
+            app:key="pref_default_story_type"
+            app:singleLineTitle="false"
+            app:title="Default starting page"
+            app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_compact_view"
-            app:summary="Hides points, domain and time"
             app:icon="@drawable/ic_action_compact"
-            app:title="Compact stories"    />
+            app:key="pref_compact_view"
+            app:singleLineTitle="false"
+            app:summary="Hides points, domain and time"
+            app:title="Compact stories" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
             app:defaultValue="true"
-            app:key="pref_thumbnails"
             app:icon="@drawable/ic_action_web"
-            app:title="Show story thumbnails"    />
+            app:key="pref_thumbnails"
+            app:singleLineTitle="false"
+            app:title="Show story thumbnails" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_show_points"
             app:defaultValue="true"
             app:icon="@drawable/ic_action_thumbs"
-            app:title="Show story points"    />
+            app:key="pref_show_points"
+            app:singleLineTitle="false"
+            app:title="Show story points" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_show_comments_count"
             app:defaultValue="true"
             app:icon="@drawable/ic_action_comment"
-            app:title="Show comment count"    />
+            app:key="pref_show_comments_count"
+            app:singleLineTitle="false"
+            app:title="Show comment count" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_show_index"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_index"
-            app:title="Show story indices"    />
+            app:key="pref_show_index"
+            app:singleLineTitle="false"
+            app:title="Show story indices" />
 
         <SwitchPreferenceCompat
-            app:isPreferenceVisible="false"
-            app:singleLineTitle="false"
-            app:key="pref_show_pdf_badge"
             app:defaultValue="true"
-            app:summary="Instead of titles ending in [PDF]"
             app:icon="@drawable/ic_action_pdf"
-            app:title="Show PDF badge"    />
+            app:isPreferenceVisible="false"
+            app:key="pref_show_pdf_badge"
+            app:singleLineTitle="false"
+            app:summary="Instead of titles ending in [PDF]"
+            app:title="Show PDF badge" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_compact_header"
             app:defaultValue="false"
-            app:summary="Smaller margins for 'Top stories' header"
             app:icon="@drawable/ic_action_horizontal_split"
-            app:title="Compact header"    />
+            app:key="pref_compact_header"
+            app:singleLineTitle="false"
+            app:summary="Smaller margins for 'Top stories' header"
+            app:title="Compact header" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_left_align"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_hand"
-            app:title="Left align comments button"    />
+            app:key="pref_left_align"
+            app:singleLineTitle="false"
+            app:title="Left align comments button" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_foldable_support"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_tablet"
-            app:title="Enable foldable support"   />
-      
-      <SwitchPreferenceCompat
+            app:key="pref_foldable_support"
             app:singleLineTitle="false"
-            app:key="pref_transparent_status_bar"
+            app:title="Enable foldable support" />
+
+        <SwitchPreferenceCompat
             app:defaultValue="false"
             app:icon="@drawable/ic_action_visibility"
-            app:title="Transparent status bar"    />
+            app:key="pref_transparent_status_bar"
+            app:singleLineTitle="false"
+            app:title="Transparent status bar" />
 
         <ListPreference
-            app:singleLineTitle="false"
-            app:icon="@drawable/ic_action_web"
-            app:title="Favicon provider"
-            app:key="pref_favicon_provider"
-            app:useSimpleSummaryProvider="true"
-            app:entries="@array/favicon_providers"
             app:defaultValue="Google"
-            app:entryValues="@array/favicon_providers"   />
+            app:entries="@array/favicon_providers"
+            app:entryValues="@array/favicon_providers"
+            app:icon="@drawable/ic_action_web"
+            app:key="pref_favicon_provider"
+            app:singleLineTitle="false"
+            app:title="Favicon provider"
+            app:useSimpleSummaryProvider="true" />
 
         <ListPreference
-            app:singleLineTitle="false"
-            app:icon="@drawable/ic_action_whatshot"
-            app:title="Highlight hot stories"
-            app:key="pref_hotness"
-            app:useSimpleSummaryProvider="true"
-            app:entries="@array/hotness_entries"
             app:defaultValue="-1"
-            app:entryValues="@array/hotness_values"   />
+            app:entries="@array/hotness_entries"
+            app:entryValues="@array/hotness_values"
+            app:icon="@drawable/ic_action_whatshot"
+            app:key="pref_hotness"
+            app:singleLineTitle="false"
+            app:title="Highlight hot stories"
+            app:useSimpleSummaryProvider="true" />
 
         <ListPreference
-            app:singleLineTitle="false"
-            app:icon="@drawable/ic_action_font"
-            app:title="Title and comment font"
-            app:key="pref_font"
-            app:useSimpleSummaryProvider="true"
-            app:entries="@array/font_entries"
             app:defaultValue="productsans"
-            app:entryValues="@array/font_values"   />
+            app:entries="@array/font_entries"
+            app:entryValues="@array/font_values"
+            app:icon="@drawable/ic_action_font"
+            app:key="pref_font"
+            app:singleLineTitle="false"
+            app:title="Title and comment font"
+            app:useSimpleSummaryProvider="true" />
 
     </PreferenceCategory>
 
     <PreferenceCategory
-        app:title="WebView"
-        android:layout="@layout/preference_category">
+        android:layout="@layout/preference_category"
+        app:title="WebView">
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_webview"
             app:defaultValue="true"
-            app:summary="Opens websites in the app which has a hit on performance"
             app:icon="@drawable/ic_action_browser"
-            app:title="Integrated WebView"    />
+            app:key="pref_webview"
+            app:singleLineTitle="false"
+            app:summary="Opens websites in the app which has a hit on performance"
+            app:title="Integrated WebView" />
 
         <ListPreference
-            app:dependency="pref_webview"
-            app:singleLineTitle="false"
-            app:icon="@drawable/ic_action_cache"
-            app:title="Preload websites"
-            app:key="pref_preload_webview"
-            app:useSimpleSummaryProvider="true"
-            app:entries="@array/preload_entries"
             app:defaultValue="never"
-            app:entryValues="@array/preload_values"   />
+            app:dependency="pref_webview"
+            app:entries="@array/preload_entries"
+            app:entryValues="@array/preload_values"
+            app:icon="@drawable/ic_action_cache"
+            app:key="pref_preload_webview"
+            app:singleLineTitle="false"
+            app:title="Preload websites"
+            app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
-            app:dependency="pref_webview"
-            app:singleLineTitle="false"
-            app:key="pref_webview_match_theme"
             app:defaultValue="false"
+            app:dependency="pref_webview"
             app:icon="@drawable/ic_action_invert"
-            app:title="Match WebView dark mode to theme"    />
+            app:key="pref_webview_match_theme"
+            app:singleLineTitle="false"
+            app:title="Match WebView dark mode to theme" />
 
         <SwitchPreferenceCompat
-            app:dependency="pref_webview"
-            app:singleLineTitle="false"
-            app:key="pref_webview_adblock"
             app:defaultValue="false"
-            app:summary="May cause some sites to stop working and has a small performance penalty"
+            app:dependency="pref_webview"
             app:icon="@drawable/ic_action_block"
-            app:title="Block WebView ads"    />
+            app:key="pref_webview_adblock"
+            app:singleLineTitle="false"
+            app:summary="May cause some sites to stop working and has a small performance penalty"
+            app:title="Block WebView ads" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_redirect_nitter"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_redirect"
-            app:title="Redirect Twitter/X to Nitter"    />
+            app:key="pref_redirect_nitter"
+            app:singleLineTitle="false"
+            app:title="Redirect Twitter/X to Nitter" />
 
     </PreferenceCategory>
 
     <PreferenceCategory
-        app:title="Comments"
-        android:layout="@layout/preference_category">
+        android:layout="@layout/preference_category"
+        app:title="Comments">
 
         <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:icon="@drawable/ic_action_api"
             app:isPreferenceVisible="false"
             app:key="pref_algolia_api"
-            app:icon="@drawable/ic_action_api"
-            app:defaultValue="true"
-            app:title="Use Algolia API"    />
+            app:title="Use Algolia API" />
 
         <ListPreference
-            app:singleLineTitle="false"
-            app:icon="@drawable/ic_action_text"
-            app:title="Comments text size"
-            app:key="pref_comment_text_size"
-            app:useSimpleSummaryProvider="true"
-            app:entries="@array/font_size_entries"
             app:defaultValue="15"
-            app:entryValues="@array/font_size_values"   />
+            app:entries="@array/font_size_entries"
+            app:entryValues="@array/font_size_values"
+            app:icon="@drawable/ic_action_text"
+            app:key="pref_comment_text_size"
+            app:singleLineTitle="false"
+            app:title="Comments text size"
+            app:useSimpleSummaryProvider="true" />
 
         <ListPreference
-            app:singleLineTitle="false"
-            app:icon="@drawable/ic_action_filter"
-            app:title="Comment sorting"
-            app:key="pref_comment_sorting"
-            app:useSimpleSummaryProvider="true"
-            app:entries="@array/comment_sorting"
             app:defaultValue="Default"
-            app:entryValues="@array/comment_sorting"   />
+            app:entries="@array/comment_sorting"
+            app:entryValues="@array/comment_sorting"
+            app:icon="@drawable/ic_action_filter"
+            app:key="pref_comment_sorting"
+            app:singleLineTitle="false"
+            app:title="Comment sorting"
+            app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_collapse_parent"
             app:icon="@drawable/ic_action_comment"
-            app:title="Hide text of collapsed comment"    />
+            app:key="pref_collapse_parent"
+            app:singleLineTitle="false"
+            app:title="Hide text of collapsed comment" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
             android:defaultValue="false"
-            app:key="pref_collapse_top_level"
             app:icon="@drawable/ic_action_minimize"
-            app:title="Auto-collapse top level comments"    />
+            app:key="pref_collapse_top_level"
+            app:singleLineTitle="false"
+            app:title="Auto-collapse top level comments" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_scroll_navigation"
-            app:icon="@drawable/ic_action_explore"
-            app:title="Show navigation buttons"
-            app:summary="Navigate between top level comments"
-            app:defaultValue="false" />
-
-        <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_monochrome_comment_depth"
-            app:icon="@drawable/ic_action_colors"
             app:defaultValue="false"
+            app:icon="@drawable/ic_action_explore"
+            app:key="pref_scroll_navigation"
+            app:singleLineTitle="false"
+            app:summary="Navigate between top level comments"
+            app:title="Show navigation buttons" />
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:icon="@drawable/ic_action_colors"
+            app:key="pref_monochrome_comment_depth"
+            app:singleLineTitle="false"
             app:title="Monochrome thread indicators" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_top_level_thread_indicators"
-            app:icon="@drawable/ic_action_align_left"
             app:defaultValue="false"
+            app:icon="@drawable/ic_action_align_left"
+            app:key="pref_top_level_thread_indicators"
+            app:singleLineTitle="false"
             app:summary="Makes it easier to separate top level comments"
             app:title="Show top level thread indicators" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_always_open_comments"
-            app:icon="@drawable/ic_action_skip"
             app:defaultValue="false"
+            app:icon="@drawable/ic_action_skip"
+            app:key="pref_always_open_comments"
+            app:singleLineTitle="false"
             app:summary="Clicking a story takes you directly to the comments view"
             app:title="Always open comments" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_comments_disable_swipeback"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_swipe"
-            app:title="Disable swipe back from comments"    />
+            app:key="pref_comments_disable_swipeback"
+            app:singleLineTitle="false"
+            app:title="Disable swipe back from comments" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_comments_animation"
             app:defaultValue="true"
             app:icon="@drawable/ic_action_animation"
-            app:title="Animate comments"    />
+            app:key="pref_comments_animation"
+            app:singleLineTitle="false"
+            app:title="Animate comments" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_comments_scrollbar"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_swipe_vertical"
-            app:title="Scrollbar"    />
+            app:key="pref_comments_scrollbar"
+            app:singleLineTitle="false"
+            app:title="Scrollbar" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_comments_swap_long"
             app:defaultValue="false"
-            app:summaryOn="Current: Tap for options"
-            app:summaryOff="Current: Tap to hide/expand"
             app:icon="@drawable/ic_action_touch"
-            app:title="Swap tap/long press behavior"    />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        app:title="Link previews"
-        android:layout="@layout/preference_category">
-
-        <SwitchPreferenceCompat
-            app:icon="@drawable/ic_link_preview_arxiv"
-            app:title="ArXiV"
-            app:defaultValue="true"
-            app:key="pref_link_preview_arxiv"/>
-
-        <SwitchPreferenceCompat
-            app:icon="@drawable/ic_link_preview_github"
-            app:title="GitHub"
-            app:defaultValue="true"
-            app:key="pref_link_preview_github"/>
-
-        <SwitchPreferenceCompat
-            app:icon="@drawable/ic_link_preview_x"
-            app:title="Twitter/X"
-            app:dependency="pref_redirect_nitter"
-            app:summary="Requires Nitter redirect to be active"
-            app:defaultValue="true"
-            app:key="pref_link_preview_x"/>
-
-        <SwitchPreferenceCompat
-            app:icon="@drawable/ic_link_preview_wikipedia"
-            app:title="Wikipedia"
-            app:defaultValue="true"
-            app:key="pref_link_preview_wikipedia"/>
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        app:title="General"
-        android:layout="@layout/preference_category">
-
-        <SwitchPreferenceCompat
+            app:key="pref_comments_swap_long"
             app:singleLineTitle="false"
-            app:key="pref_external_browser"
+            app:summaryOff="Current: Tap to hide/expand"
+            app:summaryOn="Current: Tap for options"
+            app:title="Swap tap/long press behavior" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:layout="@layout/preference_category"
+        app:title="Link previews">
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:icon="@drawable/ic_link_preview_arxiv"
+            app:key="pref_link_preview_arxiv"
+            app:title="ArXiV" />
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:icon="@drawable/ic_link_preview_github"
+            app:key="pref_link_preview_github"
+            app:title="GitHub" />
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:dependency="pref_redirect_nitter"
+            app:icon="@drawable/ic_link_preview_x"
+            app:key="pref_link_preview_x"
+            app:summary="Requires Nitter redirect to be active"
+            app:title="Twitter/X" />
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:icon="@drawable/ic_link_preview_wikipedia"
+            app:key="pref_link_preview_wikipedia"
+            app:title="Wikipedia" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:layout="@layout/preference_category"
+        app:title="General">
+
+        <SwitchPreferenceCompat
             app:defaultValue="false"
-            app:title="Use external browser"
+            app:icon="@drawable/ic_action_external_browser"
+            app:key="pref_external_browser"
+            app:singleLineTitle="false"
             app:summary="In place of custom tabs"
-            app:icon="@drawable/ic_action_external_browser" />
+            app:title="Use external browser" />
 
         <EditTextPreference
-            app:singleLineTitle="false"
-            app:title="Filter stories"
-            app:key="pref_filter"
+            app:dialogMessage="Separate phrases by commas, capitalization is ignored"
             app:icon="@drawable/ic_action_filter"
+            app:key="pref_filter"
+            app:singleLineTitle="false"
             app:summary="Hide stories based on words in title"
-            app:dialogMessage="Separate phrases by commas, capitalization is ignored"  />
+            app:title="Filter stories on words" />
+        <EditTextPreference
+            app:icon="@drawable/ic_action_block"
+            app:key="pref_filter_score"
+            app:singleLineTitle="false"
+            app:summary="Hide stories based on a minimum score"
+            app:title="Filter stories on score" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_hide_jobs"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_work_off"
+            app:key="pref_hide_jobs"
+            app:singleLineTitle="false"
             app:summary="Includes &quot;Who is hiring&quot; posts"
-            app:title="Hide job posts"    />
+            app:title="Hide job posts" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_hide_clicked"
             app:defaultValue="false"
             app:icon="@drawable/ic_action_hide"
+            app:key="pref_hide_clicked"
+            app:singleLineTitle="false"
             app:summary="Applies on refresh"
-            app:title="Hide clicked posts"    />
+            app:title="Hide clicked posts" />
 
         <SwitchPreferenceCompat
-            app:singleLineTitle="false"
-            app:key="pref_show_changelog"
             app:defaultValue="true"
             app:icon="@drawable/ic_action_update"
-            app:title="Show update changelogs"    />
+            app:key="pref_show_changelog"
+            app:singleLineTitle="false"
+            app:title="Show update changelogs" />
 
         <Preference
-            app:singleLineTitle="false"
+            app:icon="@drawable/ic_action_bookmark_border"
             app:key="pref_export_bookmarks"
-            app:title="Export bookmarks"
+            app:singleLineTitle="false"
             app:summary="Exports to text file where first number of each line is post ID"
-            app:icon="@drawable/ic_action_bookmark_border" />
+            app:title="Export bookmarks" />
 
         <Preference
-            app:singleLineTitle="false"
+            app:icon="@drawable/ic_action_bookmark_filled"
             app:key="pref_import_bookmarks"
-            app:title="Import bookmarks"
+            app:singleLineTitle="false"
             app:summary="Overwrites current bookmarks"
-            app:icon="@drawable/ic_action_bookmark_filled" />
+            app:title="Import bookmarks" />
 
         <Preference
-            app:singleLineTitle="false"
+            app:icon="@drawable/ic_action_clear"
             app:key="pref_clear_clicked_stories"
-            app:title="Clear clicked stories"
-            app:icon="@drawable/ic_action_clear" />
+            app:singleLineTitle="false"
+            app:title="Clear clicked stories" />
 
         <Preference
-            app:singleLineTitle="false"
+            app:icon="@drawable/ic_action_info"
             app:key="pref_about"
-            app:title="About"
-            app:icon="@drawable/ic_action_info" />
+            app:singleLineTitle="false"
+            app:title="About" />
 
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -368,7 +368,7 @@
             app:summary="Hide stories based on words in title"
             app:title="Filter stories on words" />
         <EditTextPreference
-            app:dialogMessage="Setting this value too high may cause the UI to become janky."
+            app:dialogMessage="Setting this value too high may cause the UI to become janky and may fail to load."
             app:icon="@drawable/ic_action_block"
             app:key="pref_filter_score"
             app:singleLineTitle="false"


### PR DESCRIPTION
This is still a work in progress and would like feedback. I have added the preference and the setting works initially. 

The issue is that we are removing stories from the queue _after_ the data comes back. 

There arrives a point where we have eliminated the entire queue due to for example a filter score too high. And we only load more stories in the `onScrolled()`. So we practically reach a dead end. This is also glaringly visible when the filter was applied to types such as `Ask HN` where stories count is low. 

Perhaps we should fetch more stories based on the number of stories visible rather than `onScrolled()` only?