### PR TITLE
Add more auto themes

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
@@ -60,6 +60,9 @@ public class ThemeUtils {
                     }
                 }
                 break;
+            case "darklight_daynight":
+                activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBarDarkLightDayNight : R.style.AppThemeDarkLightDayNight);
+                break;
             case "material_dark":
                 activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBarMaterialDark : R.style.AppThemeMaterialDark);
                 break;
@@ -80,10 +83,8 @@ public class ThemeUtils {
                 break;
             //needed because of comment activity where the default is AppTheme, now swipeBack
             case "dark":
-                activity.setTheme(swipeBack ? R.style.Theme_Swipe_Back_NoActionBar : R.style.AppTheme);
-
+                activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBar : R.style.AppTheme);
                 break;
-
         }
 
         Window window = activity.getWindow();
@@ -115,7 +116,7 @@ public class ThemeUtils {
     }
 
     public static boolean isDarkMode(Context ctx, String theme) {
-        if (theme.equals("material_daynight")) {
+        if (theme.equals("material_daynight") || theme.equals("darklight_daynight")) {
             return uiModeNight(ctx);
         }
         return theme.equals("amoled") || theme.equals("dark") || theme.equals("gray") || theme.equals("material_dark");
@@ -148,6 +149,8 @@ public class ThemeUtils {
                 return R.color.material_you_neutral_50;
             case "material_daynight":
                 return uiModeNight(ctx) ? R.color.material_you_neutral_900 : R.color.material_you_neutral_50;
+            case "darklight_daynight":
+                return uiModeNight(ctx) ? R.color.background : R.color.lightBackground;
             case "dark":
                 return R.color.background;
             default:

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
@@ -4,10 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.view.Window;
-import android.view.WindowManager;
 
 import androidx.activity.ComponentActivity;
 import androidx.activity.EdgeToEdge;

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
@@ -15,7 +15,9 @@ import androidx.preference.PreferenceManager;
 
 import com.simon.harmonichackernews.R;
 
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class ThemeUtils {
@@ -62,6 +64,9 @@ public class ThemeUtils {
                 break;
             case "darklight_daynight":
                 activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBarDarkLightDayNight : R.style.AppThemeDarkLightDayNight);
+                break;
+            case "amoledwhite_daynight":
+                activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBarAmoledWhiteDayNight : R.style.AppThemeAmoledWhiteDayNight);
                 break;
             case "material_dark":
                 activity.setTheme(swipeBack ? R.style.ThemeSwipeBackNoActionBarMaterialDark : R.style.AppThemeMaterialDark);
@@ -116,12 +121,15 @@ public class ThemeUtils {
     }
 
     public static boolean isDarkMode(Context ctx, String theme) {
-        if (theme.equals("material_daynight") || theme.equals("darklight_daynight")) {
+        List<String> dynamicThemes = Arrays.asList("material_daynight", "darklight_daynight", "amoledwhite_daynight");
+        List<String> darkThemes = Arrays.asList("amoled", "dark", "grey", "material_dark");
+
+        if (dynamicThemes.contains(theme)) {
             return uiModeNight(ctx);
         }
-        return theme.equals("amoled") || theme.equals("dark") || theme.equals("gray") || theme.equals("material_dark");
+        return darkThemes.contains(theme);
     }
-    
+
     public static boolean isDarkMode(Context ctx) {
         String theme = getPreferredTheme(ctx);
         return isDarkMode(ctx, theme);
@@ -151,6 +159,8 @@ public class ThemeUtils {
                 return uiModeNight(ctx) ? R.color.material_you_neutral_900 : R.color.material_you_neutral_50;
             case "darklight_daynight":
                 return uiModeNight(ctx) ? R.color.background : R.color.lightBackground;
+            case "amoledwhite_daynight":
+                return uiModeNight(ctx) ? android.R.color.black : R.color.whiteBackground;
             case "dark":
                 return R.color.background;
             default:

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ThemeUtils.java
@@ -122,7 +122,7 @@ public class ThemeUtils {
 
     public static boolean isDarkMode(Context ctx, String theme) {
         List<String> dynamicThemes = Arrays.asList("material_daynight", "darklight_daynight", "amoledwhite_daynight");
-        List<String> darkThemes = Arrays.asList("amoled", "dark", "grey", "material_dark");
+        List<String> darkThemes = Arrays.asList("amoled", "dark", "gray", "material_dark");
 
         if (dynamicThemes.contains(theme)) {
             return uiModeNight(ctx);

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -7,4 +7,9 @@
     <style name="AppThemeDarkLightDayNight" parent="AppTheme"></style>
 
     <style name="ThemeSwipeBackNoActionBarDarkLightDayNight" parent="ThemeSwipeBackNoActionBar"></style>
+
+    <style name="AppThemeAmoledWhiteDayNight" parent="AppThemeAmoledDark"></style>
+
+    <style name="ThemeSwipeBackNoActionBarAmoledWhiteDayNight" parent="ThemeSwipeBackNoActionBarAmoledDark"></style>
+
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -4,4 +4,7 @@
 
     <style name="ThemeSwipeBackNoActionBarMaterialDayNight" parent="ThemeSwipeBackNoActionBarMaterialDark"></style>
 
+    <style name="AppThemeDarkLightDayNight" parent="AppTheme"></style>
+
+    <style name="ThemeSwipeBackNoActionBarDarkLightDayNight" parent="ThemeSwipeBackNoActionBar"></style>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -20,6 +20,7 @@
     <string-array name="theme_entries">
         <item>Material You (auto)</item>
         <item>Dark/Light (auto)</item>
+        <item>Black/White (auto)</item>
         <item>Dark</item>
         <item>Material You (dark)</item>
         <item>Gray</item>
@@ -32,6 +33,7 @@
     <string-array name="theme_values">
         <item>material_daynight</item>
         <item>darklight_daynight</item>
+        <item>amoledwhite_daynight</item>
         <item>dark</item>
         <item>material_dark</item>
         <item>gray</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -19,6 +19,7 @@
 
     <string-array name="theme_entries">
         <item>Material You (auto)</item>
+        <item>Dark/Light (auto)</item>
         <item>Dark</item>
         <item>Material You (dark)</item>
         <item>Gray</item>
@@ -30,6 +31,7 @@
 
     <string-array name="theme_values">
         <item>material_daynight</item>
+        <item>darklight_daynight</item>
         <item>dark</item>
         <item>material_dark</item>
         <item>gray</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -8,6 +8,8 @@
     <!-- This is just for daynight, there is another theme resource in the night folder-->
     <style name="AppThemeMaterialDayNight" parent="AppThemeMaterialLight"></style>
 
+    <style name="AppThemeDarkLightDayNight" parent="AppThemeLight"></style>
+
     <style name="AppThemeMaterialDark" parent="@style/AppThemeBase">
         <item name="storyColorNormal">@color/darkStoryColorNormal</item>
         <item name="storyColorDisabled">@color/darkStoryColorDisabled</item>
@@ -167,12 +169,14 @@
 
 
 
-    <style name="Theme.Swipe.Back.NoActionBar" parent="AppTheme">
+    <style name="ThemeSwipeBackNoActionBar" parent="AppTheme">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 
     <style name="ThemeSwipeBackNoActionBarMaterialDayNight" parent="ThemeSwipeBackNoActionBarMaterialLight"></style>
+
+    <style name="ThemeSwipeBackNoActionBarDarkLightDayNight" parent="ThemeSwipeBackNoActionBarLight"></style>
 
     <style name="ThemeSwipeBackNoActionBarMaterialDark" parent="@style/AppThemeMaterialDark">
         <item name="android:windowIsTranslucent">true</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,6 +10,8 @@
 
     <style name="AppThemeDarkLightDayNight" parent="AppThemeLight"></style>
 
+    <style name="AppThemeAmoledWhiteDayNight" parent="AppThemeWhite"></style>
+
     <style name="AppThemeMaterialDark" parent="@style/AppThemeBase">
         <item name="storyColorNormal">@color/darkStoryColorNormal</item>
         <item name="storyColorDisabled">@color/darkStoryColorDisabled</item>
@@ -177,6 +179,8 @@
     <style name="ThemeSwipeBackNoActionBarMaterialDayNight" parent="ThemeSwipeBackNoActionBarMaterialLight"></style>
 
     <style name="ThemeSwipeBackNoActionBarDarkLightDayNight" parent="ThemeSwipeBackNoActionBarLight"></style>
+
+    <style name="ThemeSwipeBackNoActionBarAmoldedWhiteDayNight" parent="ThemeSwipeBackNoActionBarWhite"></style>
 
     <style name="ThemeSwipeBackNoActionBarMaterialDark" parent="@style/AppThemeMaterialDark">
         <item name="android:windowIsTranslucent">true</item>


### PR DESCRIPTION
I added two more automatic themes for dark/light and black/light, which should address issue #118.

While this works as expected I have a couple of questions about some code pieces I stumbled upon.

### API level checks
In `ThemeUtil.java` there is the following api level check just for the material theme:
```Java
 switch (theme) {
            case "material_daynight":
                //below 30, default on comments is swipeBack so if we don't use it we need to change to a normal theme
                if (Build.VERSION.SDK_INT < 30) {
                    if (!swipeBack) {
                        activity.setTheme(R.style.AppThemeMaterialDayNight);
                    }
                } else {
                    //at and above 30, the default is AppTheme so if we use swipeBack we need to change
                    if (swipeBack) {
                        activity.setTheme(R.style.ThemeSwipeBackNoActionBarMaterialDayNight);
                    }
                }
                break;
```

I don't quite get why that logic would only be necessary for that theme. Moreover, it seems faulty to me, like if we are on build level over 30 we would just not update the theme if swipeBack is disabled? Maybe I am overlooking something here.

### Change auto theme naming

I currently kept your naming convention of `{theme}_daynight` for the automatic themes, however since they are not really dependent on the time but often on the system settings I think `dynamic` or `automatic` would be a better term.



As always feedback is welcome.