### PR TITLE
Add the direction of the vote to the toast

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/network/UserActions.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/UserActions.java
@@ -70,7 +70,13 @@ private static final String HEADER_SET_COOKIE = "set-cookie";
         UserActions.vote(String.valueOf(id), dir, ctx, fm, new UserActions.ActionCallback() {
             @Override
             public void onSuccess(Response response) {
-                Toast.makeText(ctx, "Vote successful", Toast.LENGTH_SHORT).show();
+                String message = "Vote successful";
+                switch (dir) {
+                    case VOTE_DIR_UP: message = "Upvote successful"; break;
+                    case VOTE_DIR_DOWN: message = "Downvote successful"; break;
+                    case VOTE_DIR_UN: message= "Removed vote successfully"; break;
+                }
+                Toast.makeText(ctx, message, Toast.LENGTH_SHORT).show();
             }
 
             @Override


### PR DESCRIPTION
As jonas-w mentioned in #161 the voting direction (upvote, downvote or vote removing) isn't mentioned in the toast. To give better feedback of the action taken this commit now includes them. Since the information was already available in the method it was quite straight forward to implement it.

**Screenshot**:
![Screenshot_20240412_201351](https://github.com/SimonHalvdansson/Harmonic-HN/assets/21206831/caaf8ebe-fec1-4a94-83a8-3475ecd519b5)
