### PR TITLE
Display the debug indicator on the about page

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/AboutActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/AboutActivity.java
@@ -26,9 +26,8 @@ public class AboutActivity extends AppCompatActivity {
         setContentView(R.layout.activity_about);
 
         String versionText = "Version " + BuildConfig.VERSION_NAME;
-        if (BuildConfig.BUILD_TYPE != "release") {
-            String buildName = BuildConfig.BUILD_TYPE.substring(0, 1).toUpperCase() + BuildConfig.BUILD_TYPE.substring(1);
-            versionText += String.format(" · %s Build!", buildName);
+        if (BuildConfig.DEBUG) {
+            versionText += String.format(" (%s)", BuildConfig.BUILD_TYPE);
         }
         ((TextView) findViewById(R.id.about_version)).setText(versionText);
     }

--- a/app/src/main/java/com/simon/harmonichackernews/AboutActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/AboutActivity.java
@@ -25,7 +25,12 @@ public class AboutActivity extends AppCompatActivity {
         ThemeUtils.setupTheme(this, false);
         setContentView(R.layout.activity_about);
 
-        ((TextView) findViewById(R.id.about_version)).setText("Version " + BuildConfig.VERSION_NAME);
+        String versionText = "Version " + BuildConfig.VERSION_NAME;
+        if (BuildConfig.BUILD_TYPE != "release") {
+            String buildName = BuildConfig.BUILD_TYPE.substring(0, 1).toUpperCase() + BuildConfig.BUILD_TYPE.substring(1);
+            versionText += String.format(" · %s Build!", buildName);
+        }
+        ((TextView) findViewById(R.id.about_version)).setText(versionText);
     }
 
     public void openGithub(View v) {

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -178,6 +178,7 @@
 
 
         <Button
+            android:layout_marginBottom="24dp"
             android:fontFamily="@font/product_sans_bold"
             style="@style/Widget.Material3.Button.OutlinedButton.Icon"
             app:icon="@drawable/ic_action_policy"

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -154,7 +154,7 @@
             android:layout_height="wrap_content"/>
 
         <Button
-            android:layout_marginTop="12dp"
+            android:layout_marginTop="16dp"
             android:fontFamily="@font/product_sans_bold"
             style="@style/Widget.Material3.Button.OutlinedButton.Icon"
             app:icon="@drawable/ic_link_preview_github"
@@ -178,7 +178,7 @@
 
 
         <Button
-            android:layout_marginBottom="24dp"
+            android:layout_marginBottom="16dp"
             android:fontFamily="@font/product_sans_bold"
             style="@style/Widget.Material3.Button.OutlinedButton.Icon"
             app:icon="@drawable/ic_action_policy"


### PR DESCRIPTION
While deploying a custom version of the app to my phone I wanted to be sure that the deployed app really is the release version.

Therefore I added this warning in the about section if the app is not a release version. On release build nothing changed. While most users hopefully should never see this, it should make it easier for devs to troubleshoot problems.

The commit also adds padding to the last button on the about page so that it doesn't hug the bottom that much.

**Screenshot:**
![Screenshot 2024-04-15 at 18 12 55](https://github.com/SimonHalvdansson/Harmonic-HN/assets/21206831/e2643e1b-ac9a-4414-bbcd-88f1d647a32b)
