### PR TITLE
Modernize Build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - updated-build-action
   pull_request:
   workflow_dispatch:
 
@@ -10,13 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
-      - uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build --warning-mode all
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Build with Gradle
+        run: ./gradlew build --warning-mode all
       - uses: actions/upload-artifact@v3
         with:
           name: apks

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,14 +13,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 17
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          cache-read-only: false
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+#      - name: Setup Gradle
+#        uses: gradle/actions/setup-gradle@v3
+#        with:
+#          cache-read-only: false
       - name: Build with Gradle
-        run: ./gradlew build --warning-mode all
+        run: ./gradlew build --warning-mode all --no-daemon --parallel
       - uses: actions/upload-artifact@v3
         with:
           name: apks

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
 #          cache-read-only: false
       - name: Build with Gradle
         run: ./gradlew build --warning-mode all --no-daemon --parallel
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: apks
           path: app/build/outputs/apk

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - updated-build-action
   pull_request:
   workflow_dispatch:
 
@@ -16,10 +15,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
-#      - name: Setup Gradle
-#        uses: gradle/actions/setup-gradle@v3
-#        with:
-#          cache-read-only: false
       - name: Build with Gradle
         run: ./gradlew build --warning-mode all --no-daemon --parallel
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build with Gradle
+        with:
+          cache-read-only: false
         run: ./gradlew build --warning-mode all
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,9 +17,9 @@ jobs:
           java-version: 17
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Build with Gradle
         with:
           cache-read-only: false
+      - name: Build with Gradle
         run: ./gradlew build --warning-mode all
       - uses: actions/upload-artifact@v3
         with:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,9 @@ android {
     lint {
         disable 'NotificationPermission'
     }
+    buildFeatures {
+        buildConfig true
+    }
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    id('com.android.application') version '8.2.0' apply false
+    id('com.android.application') version '8.3.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,6 @@ org.gradle.jvmargs=-Xms1024m -Xmx4096m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.useAndroidX=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 org.gradle.unsafe.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Nov 12 13:07:01 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
This PR updates gradle and the build actions, fixes some deprecation warnings and improves CI speed from around 12min down to 3min. Of course the first commit with the new CI won't be any faster as there won't be a cache but future build should benefit from the cache.

Most of the speedup comes from a better/more agressive cache strategy.