### PR TITLE
Add history view

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -618,6 +618,34 @@ public class StoriesFragment extends Fragment {
             swipeRefreshLayout.setRefreshing(false);
 
             return;
+        } else if (adapter.type == SettingsUtils.getHistoryIndex(getResources())) {
+            // lets load bookmarks instead - or rather add empty stories with correct id:s and start loading them
+            adapter.notifyItemRangeRemoved(1, stories.size() + 1);
+            loadedTo = 0;
+
+            stories.clear();
+            stories.add(new Story());
+            int[] clickIdsArray = new int[clickedIds.size()];
+
+            int j = 0;
+            for (int id: clickedIds){
+                clickIdsArray[j++] = id;
+            }
+
+            for (int i = 0; i < clickedIds.size(); i++) {
+                Story s = new Story("Loading...", clickIdsArray[i], false, false);
+
+                stories.add(s);
+                adapter.notifyItemInserted(i + 1);
+                if (i < 20) {
+                    loadStory(stories.get(i + 1), 0);
+                }
+            }
+
+            adapter.notifyItemChanged(0);
+            swipeRefreshLayout.setRefreshing(false);
+
+            return;
         }
 
         // if none of the above, do a normal loading

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Changelog.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Changelog.java
@@ -2,7 +2,10 @@ package com.simon.harmonichackernews.utils;
 
 public class Changelog {
     static public String getHTML() {
-        return "<b>Version 2.0.3:</b><br>" +
+        return "<b>Version 2.1:</b><br>" +
+                "- Add history view (thanks Fernando F. H.!)<br>" +
+                "<br>" +
+                "<b>Version 2.0.3:</b><br>" +
                 "- Removed Nitter integration (RIP)<br>" +
                 "- Fixed long comment links opened on long press (thanks flofriday!)<br>" +
                 "- Added vote direction in toast (thanks flofriday!)<br>" +

--- a/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
@@ -239,6 +239,18 @@ public class SettingsUtils {
         return sortingOptions.length - 1;
     }
 
+    public static int getHistoryIndex(Resources res) {
+        String[] sortingOptions = res.getStringArray(R.array.sorting_options);
+
+        for (int i = sortingOptions.length - 1; i >= 0; i--) {
+            if (sortingOptions[i].equals("History")) {
+                return i;
+            }
+        }
+        // fallback
+        return sortingOptions.length - 1;
+    }
+
     public static int getJobsIndex(Resources res) {
         String[] sortingOptions = res.getStringArray(R.array.sorting_options);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
         <item>Show HN</item>
         <item>HN Jobs</item>
         <item>Bookmarks</item>
+        <item>History</item>
     </string-array>
 
     <string-array name="search_sorting_options">


### PR DESCRIPTION
This commit introduces a new view for displaying the user's browsing history.

The `attemptRefresh()` method now handles loading and displaying stories from the user's history when the `adapter.type` is set to the history index.

This feature enhances the user experience by providing a convenient way to access previously viewed stories.

![Screenshot_20240618_103519](https://github.com/SimonHalvdansson/Harmonic-HN/assets/13169527/0eb7771d-d127-40de-a69d-0ee8e3274210)
![Screenshot_20240618_103536](https://github.com/SimonHalvdansson/Harmonic-HN/assets/13169527/32711a93-4dd0-4a86-a7cc-cf33bca0b942)
