### PR TITLE
Enable foldable support for Z Fold 6

### DIFF
--- a/app/src/main/res/xml/main_split_config.xml
+++ b/app/src/main/res/xml/main_split_config.xml
@@ -5,7 +5,7 @@
   <SplitPairRule
     window:splitRatio="0.5"
     window:splitLayoutDirection="locale"
-    window:splitMinWidthDp="840"
+    window:splitMinWidthDp="700"
     window:splitMaxAspectRatioInPortrait="alwaysAllow"
     window:finishPrimaryWithSecondary="never"
     window:finishSecondaryWithPrimary="always"
@@ -19,7 +19,7 @@
     window:placeholderActivityName=".SplitPlaceholderActivity"
     window:splitRatio="0.5"
     window:splitLayoutDirection="locale"
-    window:splitMinWidthDp="840"
+    window:splitMinWidthDp="700"
     window:splitMaxAspectRatioInPortrait="alwaysAllow"
     window:stickyPlaceholder="false">
     <ActivityFilter


### PR DESCRIPTION
This PR makes the "foldable mode" work with the Galaxy Z fold 6. When unfolded, the Z Fold 6 seems to be 707dp in width (portrait mode), which was less than the 840 configured in `main_split_config.xml`.

### Portrait
![Screenshot_20240812_003021](https://github.com/user-attachments/assets/1ccb45c1-a0f0-4f88-88d9-db0fadbe2eca)

### Landscape
![Screenshot_20240812_003123](https://github.com/user-attachments/assets/462f228a-4225-4a31-96c6-208b91e90a22)