### PR TITLE
Add preference to filter comments by configured usernames

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -117,6 +117,7 @@ import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import okhttp3.Call;
 
@@ -173,6 +174,7 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
     private OnBackPressedCallback backPressedCallback;
     private String username;
     private Story story;
+    private Set<String> filteredUsers;
 
     public CommentsFragment() {
         super(R.layout.fragment_comments);
@@ -181,6 +183,8 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        filteredUsers = Utils.getFilteredUsers(getContext());
 
         setExitTransition(new MaterialSharedAxis(MaterialSharedAxis.Y, true));
         setEnterTransition(new MaterialSharedAxis(MaterialSharedAxis.Y, false));
@@ -1245,7 +1249,7 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
             // We run the default sorting
             boolean addedNewComment = false;
             for (int i = 0; i < children.length(); i++) {
-                boolean added = JSONParser.readChildAndParseSubchilds(children.getJSONObject(i), comments, adapter, 0, story.kids);
+                boolean added = JSONParser.readChildAndParseSubchilds(children.getJSONObject(i), comments, adapter, 0, story.kids, filteredUsers);
                 if (added) {
                     addedNewComment = true;
                 }

--- a/app/src/main/java/com/simon/harmonichackernews/network/JSONParser.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/JSONParser.java
@@ -13,11 +13,11 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class JSONParser {
 
     public final static String ALGOLIA_ERROR_STRING = "{\"status\":404,\"error\":\"Not Found\"}";
-
     public static List<Story> algoliaJsonToStories(String response) throws JSONException {
         List<Story> stories = new ArrayList<>();
 
@@ -264,7 +264,7 @@ public class JSONParser {
         return changed;
     }
 
-    public static boolean readChildAndParseSubchilds(JSONObject child, List<Comment> comments, CommentsRecyclerViewAdapter adapter, int depth, int[] prioTop) throws JSONException {
+    public static boolean readChildAndParseSubchilds(JSONObject child, List<Comment> comments, CommentsRecyclerViewAdapter adapter, int depth, int[] prioTop, Set<String> filteredUsers) throws JSONException {
         /*
          * Remark: Right now we're only updating old comments, not deleting those who are not there
          * anymore but that is probably just nice
@@ -275,6 +275,10 @@ public class JSONParser {
         if (!child.has("text") || child.getString("text").equals("null")) {
             return false;
         }
+        String author = child.getString("author");
+        if (filteredUsers.contains(author)){
+            return false;
+        }
 
         JSONArray children = child.has("children") ? child.getJSONArray("children") : null;
 
@@ -283,7 +287,7 @@ public class JSONParser {
         comment.depth = depth;
         comment.parent = child.getInt("parent_id");
         comment.expanded = true;
-        comment.by = child.getString("author");
+        comment.by = author;
         comment.text = preprocessHtml(child.getString("text"));
         comment.time = child.getInt("created_at_i");
         comment.id = child.getInt("id");
@@ -423,7 +427,7 @@ public class JSONParser {
 
         if (children != null) {
             for (int i = 0; i < children.length(); i++) {
-                boolean childPlaced = readChildAndParseSubchilds(children.getJSONObject(i), comments, adapter, depth + 1, prioTop);
+                boolean childPlaced = readChildAndParseSubchilds(children.getJSONObject(i), comments, adapter, depth + 1, prioTop, filteredUsers);
                 if (childPlaced) {
                     placedNew = true;
                 }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
@@ -303,6 +303,19 @@ public class Utils {
         return phrases;
     }
 
+    public static Set<String> getFilteredUsers(Context ctx) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
+        String prefText = prefs.getString("pref_filter_users", null);
+
+        Set<String> usernames = new HashSet<>();
+        if (!TextUtils.isEmpty(prefText)) {
+            for (String username : prefText.split(",")) {
+                usernames.add(username.trim());
+            }
+        }
+        return usernames;
+    }
+
     public static boolean isFirstAppStart(Context ctx) {
         SharedPreferences sharedPref = ctx.getSharedPreferences(GLOBAL_SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
         if (sharedPref.getBoolean(KEY_SHARED_PREFERENCES_FIRST_TIME, true) && SettingsUtils.readIntSetFromSharedPreferences(ctx, Utils.KEY_SHARED_PREFERENCES_CLICKED_IDS).isEmpty()) {

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -360,6 +360,13 @@
             app:icon="@drawable/ic_action_block"
             app:summary="Hide stories based on domain name"
             app:dialogMessage="Separate phrases by commas, capitalization is ignored"  />
+        <EditTextPreference
+            app:singleLineTitle="false"
+            app:title="Filter user comments"
+            app:key="pref_filter_users"
+            app:icon="@drawable/ic_action_block"
+            app:summary="Hide comments by the specified users"
+            app:dialogMessage="Separate usernames by commas, capitalization is ignored"  />
 
         <SwitchPreferenceCompat
             app:singleLineTitle="false"


### PR DESCRIPTION
This adds the ability to completely hide comments from certain usernames. The usernames are specified in a comma-separated list like the existing domain and title-based filtering.

My goal was to quickly patch in the feature for myself so it's probably not done in the most correct way, but it's functional.

I'm willing to work with you to refactor it if you're interested in adding this feature but have a better idea on how to implement it.