### PR TITLE
Rework history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ deploymentTargetDropDown.xml
 .externalNativeBuild
 .cxx
 *.pepk
+
+# kotlin
+.kotlin/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id('com.android.application')
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {
@@ -20,6 +21,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 
     buildTypes {
@@ -65,5 +69,4 @@ dependencies {
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
     implementation 'com.squareup.picasso:picasso:2.8'
     implementation 'org.jsoup:jsoup:1.16.2'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.20'
 }

--- a/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
@@ -1,5 +1,7 @@
 package com.simon.harmonichackernews;
 
+import static com.simon.harmonichackernews.utils.UtilsKt.KEY_SHARED_PREFERENCES_HISTORIES;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -24,9 +26,11 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.timepicker.MaterialTimePicker;
 import com.google.android.material.timepicker.TimeFormat;
 import com.simon.harmonichackernews.data.Bookmark;
+import com.simon.harmonichackernews.utils.HistoriesUtils;
 import com.simon.harmonichackernews.utils.SettingsUtils;
 import com.simon.harmonichackernews.utils.ThemeUtils;
 import com.simon.harmonichackernews.utils.Utils;
+import com.simon.harmonichackernews.utils.UtilsKt;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -232,10 +236,9 @@ public class SettingsActivity extends AppCompatActivity {
             findPreference("pref_clear_clicked_stories").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                 @Override
                 public boolean onPreferenceClick(@NonNull Preference preference) {
-                    Set<Integer> set = SettingsUtils.readIntSetFromSharedPreferences(requireContext(), Utils.KEY_SHARED_PREFERENCES_CLICKED_IDS);
-                    int oldCount = set.size();
+                    int oldCount = HistoriesUtils.INSTANCE.size();
 
-                    SettingsUtils.saveIntSetToSharedPreferences(getContext(), Utils.KEY_SHARED_PREFERENCES_CLICKED_IDS, new HashSet<>(0));
+                    SettingsUtils.saveStringToSharedPreferences(getContext(), KEY_SHARED_PREFERENCES_HISTORIES, "");
                     if (getActivity() != null && getActivity() instanceof SettingsActivity) {
                         ((SettingsActivity) getActivity()).backPressedCallback.setEnabled(true);
                     }

--- a/app/src/main/java/com/simon/harmonichackernews/data/History.kt
+++ b/app/src/main/java/com/simon/harmonichackernews/data/History.kt
@@ -1,0 +1,3 @@
+package com.simon.harmonichackernews.data
+
+data class History(val id: Int, val created: Long)

--- a/app/src/main/java/com/simon/harmonichackernews/data/Story.java
+++ b/app/src/main/java/com/simon/harmonichackernews/data/Story.java
@@ -43,6 +43,14 @@ public class Story {
         this.clicked = clicked;
     }
 
+    public Story(String title, int id, boolean loaded, boolean clicked, long time) {
+        this.title = title;
+        this.id = id;
+        this.loaded = loaded;
+        this.clicked = clicked;
+        this.time = (int) (time/1000);
+    }
+
     public void update(String by, int id, int score, int time, String title) {
         this.by = by;
         this.id = id;

--- a/app/src/main/java/com/simon/harmonichackernews/network/JSONParser.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/JSONParser.java
@@ -80,7 +80,7 @@ public class JSONParser {
         return stories;
     }
 
-    public static boolean updateStoryWithHNJson(String response, Story story) throws JSONException {
+    public static boolean updateStoryWithHNJson(String response, Story story, boolean isHistory) throws JSONException {
         if (response.equals(JSON_NULL_LITERAL)) {
             return false;
         }
@@ -99,7 +99,7 @@ public class JSONParser {
                 jsonObject.getString("by"),
                 jsonObject.getInt("id"),
                 jsonObject.getInt("score"),
-                jsonObject.getInt("time"),
+                isHistory ? story.time : jsonObject.getInt("time"),
                 jsonObject.getString("title")
         );
 

--- a/app/src/main/java/com/simon/harmonichackernews/utils/HistoriesUtils.kt
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/HistoriesUtils.kt
@@ -1,0 +1,37 @@
+package com.simon.harmonichackernews.utils
+
+import android.content.Context
+import com.simon.harmonichackernews.data.History
+
+object HistoriesUtils {
+
+    fun init(context: Context) {
+        histories.clear()
+        histories.addAll(UtilsKt.loadHistories(context, true))
+    }
+
+    private val histories = mutableListOf<History>()
+
+    fun size() = histories.size
+
+    fun addHistory(context: Context, id: Int) {
+        if (isHistoryExist(id).not()) {
+            val now = System.currentTimeMillis()
+            histories.add(History(id, now))
+            UtilsKt.addHistory(context, id)
+        }
+    }
+
+    fun getHistorybyId(id: Int): History? {
+        return histories.find { it.id == id }
+    }
+
+    fun removeHistoryById(context: Context, id: Int) {
+        histories.find { it.id == id }?.let { histories.remove(it) }
+        UtilsKt.removeHistory(context, id)
+    }
+
+    fun isHistoryExist(id: Int): Boolean {
+        return histories.any { it.id == id }
+    }
+}

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
@@ -2,6 +2,8 @@ package com.simon.harmonichackernews.utils;
 
 import static androidx.browser.customtabs.CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION;
 
+import static com.simon.harmonichackernews.utils.UtilsKt.KEY_SHARED_PREFERENCES_HISTORIES;
+
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -63,7 +65,6 @@ public class Utils {
     private static final long DAY_MILLIS = 24 * HOUR_MILLIS;
     private static final long YEAR_MILLIS = 365 * DAY_MILLIS;
 
-    public final static String KEY_SHARED_PREFERENCES_CLICKED_IDS = "com.simon.harmonichackernews.KEY_SHARED_PREFERENCES_CLICKED_IDS";
     public final static String KEY_SHARED_PREFERENCES_CACHED_STORY = "com.simon.harmonichackernews.KEY_SHARED_PREFERENCES_CACHED_STORY";
     public final static String KEY_SHARED_PREFERENCES_CACHED_STORIES_STRINGS = "com.simon.harmonichackernews.KEY_SHARED_PREFERENCES_CACHED_STORIES_STRINGS";
     public final static String GLOBAL_SHARED_PREFERENCES_KEY = "com.simon.harmonichackernews.GLOBAL_SHARED_PREFERENCES_KEY";
@@ -343,7 +344,7 @@ public class Utils {
 
     public static boolean isFirstAppStart(Context ctx) {
         SharedPreferences sharedPref = ctx.getSharedPreferences(GLOBAL_SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
-        if (sharedPref.getBoolean(KEY_SHARED_PREFERENCES_FIRST_TIME, true) && SettingsUtils.readIntSetFromSharedPreferences(ctx, Utils.KEY_SHARED_PREFERENCES_CLICKED_IDS).isEmpty()) {
+        if (sharedPref.getBoolean(KEY_SHARED_PREFERENCES_FIRST_TIME, true) && SettingsUtils.readStringFromSharedPreferences(ctx, KEY_SHARED_PREFERENCES_HISTORIES).isEmpty()) {
             sharedPref.edit().putBoolean(KEY_SHARED_PREFERENCES_FIRST_TIME, false).apply();
             return true;
         }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/UtilsKt.kt
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/UtilsKt.kt
@@ -1,0 +1,80 @@
+package com.simon.harmonichackernews.utils
+
+import android.content.Context
+import com.simon.harmonichackernews.data.History
+
+object UtilsKt {
+    private const val KEY_SHARED_PREFERENCES_HISTORIES: String = "com.simon.harmonichackernews" +
+            ".KEY_SHARED_PREFERENCES_HISTORIES"
+
+    fun loadHistories(ctx: Context, sorted: Boolean): MutableList<History> {
+        return loadHistories(
+            sorted,
+            SettingsUtils.readStringFromSharedPreferences(ctx, KEY_SHARED_PREFERENCES_HISTORIES)
+        )
+    }
+
+    private fun loadHistories(sorted: Boolean, historyString: String?): MutableList<History> {
+        /* Format is {{ID}}q{{TIME}}-{{ID}}q{{TIME}}... */
+
+        val histories: MutableList<History> = mutableListOf()
+
+        if (historyString.isNullOrEmpty()) {
+            return histories
+        }
+
+        val pairs = historyString.split("-".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        for (pair in pairs) {
+            val info = pair.split("q".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+
+            if (info.size == 2) {
+                val h = History(info[0].toInt(), info[1].toLong())
+                histories.add(h)
+            }
+        }
+
+        if (sorted) {
+            histories.sortByDescending { it.created }
+        }
+
+        return histories
+    }
+
+    private fun saveHistories(ctx: Context, histories: MutableList<History>) {
+        val sb = StringBuilder()
+        val size = histories.size
+
+        for (i in 0..<size) {
+            val b = histories[i]
+            sb.append(b.id)
+            sb.append("q")
+            sb.append(b.created)
+            if (i != size - 1) {
+                sb.append("-")
+            }
+        }
+
+        SettingsUtils.saveStringToSharedPreferences(ctx, KEY_SHARED_PREFERENCES_HISTORIES, sb.toString())
+    }
+
+    fun addHistory(ctx: Context, id: Int) {
+        val histories: MutableList<History> = loadHistories(ctx, false)
+        val b = History(id, System.currentTimeMillis())
+        histories.add(b)
+        histories.sortByDescending { it.created }
+        saveHistories(ctx, histories)
+    }
+
+    fun removeHistory(ctx: Context, id: Int) {
+        val bookmarks: MutableList<History> = loadHistories(ctx, false)
+
+        for (bookmark in bookmarks) {
+            if (bookmark.id == id) {
+                bookmarks.remove(bookmark)
+                break
+            }
+        }
+
+        saveHistories(ctx, bookmarks)
+    }
+}

--- a/app/src/main/java/com/simon/harmonichackernews/utils/UtilsKt.kt
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/UtilsKt.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.simon.harmonichackernews.data.History
 
 object UtilsKt {
-    private const val KEY_SHARED_PREFERENCES_HISTORIES: String = "com.simon.harmonichackernews" +
+    const val KEY_SHARED_PREFERENCES_HISTORIES: String = "com.simon.harmonichackernews" +
             ".KEY_SHARED_PREFERENCES_HISTORIES"
 
     fun loadHistories(ctx: Context, sorted: Boolean): MutableList<History> {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0"
+        ext.kotlin_version = '2.1.21'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 


### PR DESCRIPTION
My [previous implementation](https://github.com/SimonHalvdansson/Harmonic-HN/commit/167851f3598ecdc48d53b8880ea8e1f238a88554) of history doesn't have any sort mechanism. I think it's better to sort the history by clicked time. So the last clicked item is on top.

Hence, it required saving the time when the story is clicked by user.

Also the time shown on `meta_view` is not time from api response but using the time when the story is clicked.

![Screenshot_20250519_123153](https://github.com/user-attachments/assets/df272753-3037-4c43-96fb-9132c6dfa5b7)

The way history is saved to sharePrefs is similar to Bookmark.

```xml
<string name="com.simon.harmonichackernews.KEY_SHARED_PREFERENCES_HISTORIES">
44023680q1747630184892-44025484q1747630183027-44024759q1747630177525-44020591q1747630175592
</string>
```


