### PR TITLE
add upvote item to story popup menu

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -42,6 +42,7 @@ import com.simon.harmonichackernews.data.History;
 import com.simon.harmonichackernews.data.Story;
 import com.simon.harmonichackernews.network.JSONParser;
 import com.simon.harmonichackernews.network.NetworkComponent;
+import com.simon.harmonichackernews.network.UserActions;
 import com.simon.harmonichackernews.utils.AccountUtils;
 import com.simon.harmonichackernews.utils.FontUtils;
 import com.simon.harmonichackernews.utils.HistoriesUtils;
@@ -288,6 +289,15 @@ public class StoriesFragment extends Fragment {
                 boolean oldBookmarked = Utils.isBookmarked(ctx, story.id);
                 History h = HistoriesUtils.INSTANCE.getHistorybyId(story.id);
 
+                popupMenu.getMenu().add("Upvote").setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+                    @Override
+                    public boolean onMenuItemClick(@NonNull MenuItem item) {
+                        UserActions.upvote(getContext(), story.id, getParentFragmentManager());
+
+                        adapter.notifyItemChanged(position);
+                        return true;
+                    }
+                });
 
                 popupMenu.getMenu().add(oldClicked ? "Mark as unread" : "Mark as read").setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
                     @Override


### PR DESCRIPTION
Sometimes you forget to upvote a story before leaving it, this PR adds a menu item for doing so on the stories page.

<img src="https://github.com/user-attachments/assets/38cbe900-1358-47c7-93b8-31a3ade7758d" height="500px" >
