### PR TITLE
Allow calling FileDownloader from main thread

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/utils/FileDownloader.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/FileDownloader.java
@@ -7,8 +7,6 @@ import android.os.Looper;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.WorkerThread;
-
 import com.simon.harmonichackernews.network.NetworkComponent;
 
 import java.io.File;
@@ -39,7 +37,10 @@ public class FileDownloader {
         mMainHandler = new Handler(Looper.getMainLooper());
     }
 
-    @WorkerThread
+    /**
+     * Enqueues an asynchronous download for the provided URL. This method may be
+     * called from the main thread.
+     */
     public void downloadFile(String url, String mimeType, FileDownloaderCallback callback) {
         if (TextUtils.isEmpty(mCacheDir)) {
             mMainHandler.post(() -> callback.onFailure(null, null));


### PR DESCRIPTION
## Summary
- remove `@WorkerThread` annotation from `FileDownloader.downloadFile`
- document that downloads are enqueued asynchronously and can be started from the main thread

## Testing
- `./gradlew build --warning-mode all --no-daemon --parallel` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fffd2be1883229fb30e4e6543ebf1