### PR TITLE
Fix FileDownloader resource handling

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/utils/FileDownloader.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/FileDownloader.java
@@ -63,13 +63,16 @@ public class FileDownloader {
 
             @Override
             public void onResponse(@NonNull Call call, @NonNull Response response) {
-                try {
-                    BufferedSink sink = Okio.buffer(Okio.sink(outputFile));
-                    sink.writeAll(response.body().source());
-                    sink.close();
+                try (okhttp3.ResponseBody body = response.body();
+                     BufferedSink sink = Okio.buffer(Okio.sink(outputFile))) {
+                    if (body != null) {
+                        sink.writeAll(body.source());
+                    }
                     mMainHandler.post(() -> callback.onSuccess(outputFile.getPath()));
                 } catch (IOException e) {
                     this.onFailure(call, e);
+                } finally {
+                    response.close();
                 }
             }
         });


### PR DESCRIPTION
## Summary
- use try-with-resources for sink and response body in `FileDownloader`
- ensure the response is closed after writing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fffce651c832299d3ebb72ce664ce