### PR TITLE
Add Manage User Tags dialog

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/ManageUserTagsDialogFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/ManageUserTagsDialogFragment.java
@@ -1,0 +1,58 @@
+package com.simon.harmonichackernews;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatDialogFragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.simon.harmonichackernews.adapters.UserTagsAdapter;
+import com.simon.harmonichackernews.utils.Utils;
+
+import java.util.Map;
+
+public class ManageUserTagsDialogFragment extends AppCompatDialogFragment {
+
+    public static String TAG = "tag_manage_user_tags";
+
+    private UserTagsAdapter adapter;
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        super.onCreateDialog(savedInstanceState);
+
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(requireContext());
+        LayoutInflater inflater = requireActivity().getLayoutInflater();
+        View rootView = inflater.inflate(R.layout.user_tags_dialog, null);
+        builder.setView(rootView);
+        builder.setNegativeButton("Done", null);
+        AlertDialog dialog = builder.create();
+
+        RecyclerView recyclerView = rootView.findViewById(R.id.user_tags_recyclerview);
+        Map<String, String> tags = Utils.getUserTags(getContext());
+        adapter = new UserTagsAdapter(tags, username -> UserDialogFragment.showUserDialog(getParentFragmentManager(), username, accepted -> {
+            if (accepted) {
+                adapter.setItems(Utils.getUserTags(getContext()));
+                adapter.notifyDataSetChanged();
+            }
+        }));
+        recyclerView.setAdapter(adapter);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+
+        return dialog;
+    }
+
+    public static void showManageUserTagsDialog(FragmentManager fm) {
+        ManageUserTagsDialogFragment fragment = new ManageUserTagsDialogFragment();
+        fragment.show(fm, TAG);
+    }
+}

--- a/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
@@ -233,6 +233,14 @@ public class SettingsActivity extends AppCompatActivity {
                 }
             });
 
+            findPreference("pref_manage_user_tags").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(@NonNull Preference preference) {
+                    ManageUserTagsDialogFragment.showManageUserTagsDialog(getParentFragmentManager());
+                    return false;
+                }
+            });
+
             findPreference("pref_clear_clicked_stories").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                 @Override
                 public boolean onPreferenceClick(@NonNull Preference preference) {

--- a/app/src/main/java/com/simon/harmonichackernews/adapters/UserTagsAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/adapters/UserTagsAdapter.java
@@ -1,0 +1,74 @@
+package com.simon.harmonichackernews.adapters;
+
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.simon.harmonichackernews.R;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class UserTagsAdapter extends RecyclerView.Adapter<UserTagsAdapter.ViewHolder> {
+
+    private List<Map.Entry<String, String>> users;
+    private final ItemClickListener itemClickListener;
+
+    public interface ItemClickListener {
+        void onItemClick(String username);
+    }
+
+    public UserTagsAdapter(Map<String, String> tags, ItemClickListener listener) {
+        this.itemClickListener = listener;
+        setItems(tags);
+    }
+
+    public void setItems(Map<String, String> tags) {
+        this.users = new ArrayList<>(tags.entrySet());
+        Collections.sort(this.users, (a, b) -> a.getKey().compareToIgnoreCase(b.getKey()));
+    }
+
+    class ViewHolder extends RecyclerView.ViewHolder {
+        TextView textView;
+        ViewHolder(View itemView) {
+            super(itemView);
+            textView = itemView.findViewById(R.id.user_tag_item_text);
+            itemView.setOnClickListener(v -> {
+                if (itemClickListener != null) {
+                    itemClickListener.onItemClick(users.get(getAbsoluteAdapterPosition()).getKey());
+                }
+            });
+        }
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.user_tag_item, parent, false);
+        return new ViewHolder(v);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        Map.Entry<String, String> entry = users.get(position);
+        String username = entry.getKey();
+        String tag = entry.getValue();
+        if (TextUtils.isEmpty(tag)) {
+            holder.textView.setText(username);
+        } else {
+            holder.textView.setText(username + " (" + tag + ")");
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return users.size();
+    }
+}

--- a/app/src/main/res/drawable-anydpi/ic_action_report.xml
+++ b/app/src/main/res/drawable-anydpi/ic_action_report.xml
@@ -1,0 +1,38 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/drawableColor"
+    android:alpha="0.8"
+    android:autoMirrored="true">
+
+  <path
+      android:fillColor="#000000"
+      android:fillType="nonZero"
+      android:pathData="
+            M200,840
+            v-680
+            h360
+            l16,80
+            h224
+            v400
+            H520
+            l-16,-80
+            H280
+            v280
+            h-80
+            Z
+            m300,-440
+            Z
+            m86,160
+            h134
+            v-240
+            H510
+            l-16,-80
+            H280
+            v240
+            h290
+            l16,80
+            Z" />
+</vector>

--- a/app/src/main/res/drawable-anydpi/ic_action_tag.xml
+++ b/app/src/main/res/drawable-anydpi/ic_action_tag.xml
@@ -1,0 +1,43 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/drawableColor"
+    android:alpha="0.8"
+    android:autoMirrored="true">
+
+  <path
+      android:fillColor="#000000"
+      android:fillType="nonZero"
+      android:pathData="
+            M856,570 570,856
+            q-12,12 -27,18 t-30,6
+            q-15,0 -30,-6 t-27,-18
+            L103,503
+            q-11,-11 -17,-25.5 T80,447
+            v-287
+            q0,-33 23.5,-56.5 T160,80
+            h287
+            q16,0 31,6.5 t26,17.5
+            l352,353
+            q12,12 17.5,27 t5.5,30
+            q0,15 -5.5,29.5 T856,570
+            Z
+
+            M513,800
+            l286,-286 -353,-354
+            H160
+            v286
+            l353,354
+            Z
+
+            M260,320
+            q25,0 42.5,-17.5 T320,260
+            q0,-25 -17.5,-42.5 T260,200
+            q-25,0 -42.5,17.5 T200,260
+            q0,25 17.5,42.5 T260,320
+            Z
+            m220,160
+            Z" />
+</vector>

--- a/app/src/main/res/layout/user_dialog.xml
+++ b/app/src/main/res/layout/user_dialog.xml
@@ -106,6 +106,7 @@
                 tools:text="Submissions" />
 
             <Button
+                app:icon="@drawable/ic_action_tag"
                 android:minWidth="10dp"
                 android:layout_marginTop="8dp"
                 android:id="@+id/user_tag_button"
@@ -116,6 +117,7 @@
                 android:text="Set tag" />
 
             <Button
+                app:icon="@drawable/ic_action_block"
                 android:minWidth="10dp"
                 android:id="@+id/user_block_button"
                 style="@style/Widget.Material3.Button.TextButton"
@@ -125,6 +127,7 @@
                 android:text="Block" />
 
             <Button
+                app:icon="@drawable/ic_action_report"
                 android:id="@+id/user_report_button"
                 style="@style/Widget.Material3.Button.TextButton"
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/user_tag_item.xml
+++ b/app/src/main/res/layout/user_tag_item.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/user_tag_item_text"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fontFamily="@font/product_sans"
+    android:textColor="?attr/storyColorNormal"
+    android:textSize="16sp"
+    android:paddingLeft="24dp"
+    android:paddingRight="24dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    android:background="?attr/selectableItemBackground" />

--- a/app/src/main/res/layout/user_tags_dialog.xml
+++ b/app/src/main/res/layout/user_tags_dialog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:paddingTop="24dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/user_tags_recyclerview"
+        android:clipToPadding="false"
+        android:paddingBottom="24dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</LinearLayout>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -368,6 +368,12 @@
             app:summary="Hide comments by the specified users"
             app:dialogMessage="Separate usernames by commas, capitalization is ignored"  />
 
+        <Preference
+            app:singleLineTitle="false"
+            app:title="Manage user tags"
+            app:key="pref_manage_user_tags"
+            app:icon="@drawable/ic_action_block" />
+
         <SwitchPreferenceCompat
             app:singleLineTitle="false"
             app:key="pref_hide_jobs"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -372,7 +372,7 @@
             app:singleLineTitle="false"
             app:title="Manage user tags"
             app:key="pref_manage_user_tags"
-            app:icon="@drawable/ic_action_block" />
+            app:icon="@drawable/ic_action_tag" />
 
         <SwitchPreferenceCompat
             app:singleLineTitle="false"


### PR DESCRIPTION
## Summary
- add Manage User Tags dialog and adapter
- expose it via new setting below "Filter user comments"

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470515ac3c83228c03561ff2046f3f