### PR TITLE
Fix manage user tags preference summary

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/ManageUserTagsDialogFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/ManageUserTagsDialogFragment.java
@@ -4,6 +4,7 @@ import android.app.Dialog;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.content.DialogInterface;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,6 +25,7 @@ public class ManageUserTagsDialogFragment extends AppCompatDialogFragment {
     public static String TAG = "tag_manage_user_tags";
 
     private UserTagsAdapter adapter;
+    private Runnable dismissCallback;
 
     @NonNull
     @Override
@@ -51,8 +53,21 @@ public class ManageUserTagsDialogFragment extends AppCompatDialogFragment {
         return dialog;
     }
 
-    public static void showManageUserTagsDialog(FragmentManager fm) {
+    public static void showManageUserTagsDialog(FragmentManager fm, @Nullable Runnable callback) {
         ManageUserTagsDialogFragment fragment = new ManageUserTagsDialogFragment();
+        fragment.setDismissCallback(callback);
         fragment.show(fm, TAG);
+    }
+
+    public void setDismissCallback(@Nullable Runnable callback) {
+        this.dismissCallback = callback;
+    }
+
+    @Override
+    public void onDismiss(@NonNull DialogInterface dialog) {
+        super.onDismiss(dialog);
+        if (dismissCallback != null) {
+            dismissCallback.run();
+        }
     }
 }

--- a/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/SettingsActivity.java
@@ -237,7 +237,12 @@ public class SettingsActivity extends AppCompatActivity {
             findPreference("pref_manage_user_tags").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                 @Override
                 public boolean onPreferenceClick(@NonNull Preference preference) {
-                    ManageUserTagsDialogFragment.showManageUserTagsDialog(getParentFragmentManager());
+                    ManageUserTagsDialogFragment.showManageUserTagsDialog(getParentFragmentManager(), new Runnable() {
+                        @Override
+                        public void run() {
+                            updateUserTagsSubtitle();
+                        }
+                    });
                     return false;
                 }
             });
@@ -347,9 +352,11 @@ public class SettingsActivity extends AppCompatActivity {
             if (pref != null && getContext() != null) {
                 int count = Utils.getUserTags(getContext()).size();
                 if (count > 0) {
-                    pref.setSummary(count + " users with tags");
+                    pref.setSummary(count + " user" + (count == 1 ? "" : "s") + " with tag" + (count == 1 ? "" : "s"));
+                    changePrefStatus(pref, true);
                 } else {
                     pref.setSummary("");
+                    changePrefStatus(pref, false);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- show singular/plural form in user tag summary correctly
- disable manage-user-tags setting if there are no tags
- refresh the summary when the manage dialog closes

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a96c81b5c8322bc7243d1c9cc3bb7