### PR TITLE
Add comments provider setting

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/adapters/CommentsRecyclerViewAdapter.java
@@ -766,7 +766,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                 public void onClick(View view) {
                     // This switches off the algolia API
                     SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(view.getContext());
-                    prefs.edit().putBoolean("pref_algolia_api", false).apply();
+                    prefs.edit().putString("pref_comments_provider", "official").apply();
 
                     Toast.makeText(view.getContext(), "Deactivated Algolia API, this can be switched back in the settings. Try reloading", Toast.LENGTH_LONG).show();
                 }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/SettingsUtils.java
@@ -204,7 +204,8 @@ public class SettingsUtils {
     }
 
     public static boolean shouldUseAlgoliaAPI(Context ctx) {
-        return getBooleanPref("pref_algolia_api", true, ctx);
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
+        return "algolia".equals(prefs.getString("pref_comments_provider", "algolia"));
     }
 
     public static boolean getBooleanPref(String key, boolean backup, Context ctx) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -113,4 +113,14 @@
         <item>Favicon kit</item>
     </string-array>
 
+    <string-array name="comments_provider_entries">
+        <item>Algolia API</item>
+        <item>Official Hacker News API</item>
+    </string-array>
+
+    <string-array name="comments_provider_values">
+        <item>algolia</item>
+        <item>official</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -207,13 +207,6 @@
         app:title="Comments"
         android:layout="@layout/preference_category">
 
-        <SwitchPreferenceCompat
-            app:isPreferenceVisible="false"
-            app:key="pref_algolia_api"
-            app:icon="@drawable/ic_action_api"
-            app:defaultValue="true"
-            app:title="Use Algolia API"    />
-
         <ListPreference
             app:singleLineTitle="false"
             app:icon="@drawable/ic_action_text"
@@ -233,6 +226,16 @@
             app:entries="@array/comment_sorting"
             app:defaultValue="Default"
             app:entryValues="@array/comment_sorting"   />
+
+        <ListPreference
+            app:singleLineTitle="false"
+            app:key="pref_comments_provider"
+            app:icon="@drawable/ic_action_api"
+            app:title="Comments provider"
+            app:useSimpleSummaryProvider="true"
+            app:entries="@array/comments_provider_entries"
+            app:defaultValue="algolia"
+            app:entryValues="@array/comments_provider_values"   />
 
         <SwitchPreferenceCompat
             app:singleLineTitle="false"


### PR DESCRIPTION
## Summary
- Add "Comments provider" dropdown in Settings to switch between Algolia and official Hacker News APIs
- Store provider selection in shared prefs and expose via `SettingsUtils`
- Update comments adapter to switch preference when disabling Algolia

## Testing
- `./gradlew assembleDebug` *(fails: Java compiler version 21 deprecates source/target 8)*
- `./gradlew -q help`


------
https://chatgpt.com/codex/tasks/task_e_68ae29afd0c88322a83d04e666cfc683