### PR TITLE
Optimize adblock lookup using set

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -773,7 +773,7 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
             // This will crash if we have already done this, which is fine
         }
 
-        if (blockAds && TextUtils.isEmpty(Utils.adservers)) {
+        if (blockAds && Utils.adservers.isEmpty()) {
             Utils.loadAdservers(getResources());
         }
 
@@ -1862,8 +1862,9 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
                 return super.shouldInterceptRequest(view, request);
             }
             ByteArrayInputStream EMPTY = new ByteArrayInputStream("".getBytes());
-            if (!TextUtils.isEmpty(Utils.adservers)) {
-                if (Utils.adservers.contains(":::::" + request.getUrl().getHost())) {
+            if (!Utils.adservers.isEmpty()) {
+                String host = request.getUrl().getHost();
+                if (host != null && Utils.adservers.contains(host)) {
                     Utils.log("Blocked: " + request.getUrl());
                     return new WebResourceResponse("text/plain", "utf-8", EMPTY);
                 }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
@@ -142,18 +142,12 @@ public class Utils {
 
                 InputStream fis2 = resources.openRawResource(R.raw.adblockserverlist);
                 BufferedReader br2 = new BufferedReader(new InputStreamReader(fis2));
-                if (fis2 != null) {
-                    try {
-                        while ((strLine2 = br2.readLine()) != null) {
-                            if (strLine2.startsWith(":::::")) {
-                                adSet.add(strLine2.substring(5));
-                            } else {
-                                adSet.add(strLine2);
-                            }
-                        }
-                    } catch (IOException e) {
-                        e.printStackTrace();
+                try {
+                    while ((strLine2 = br2.readLine()) != null) {
+                        adSet.add(strLine2);
                     }
+                } catch (IOException e) {
+                    e.printStackTrace();
                 }
                 Utils.adservers = adSet;
             }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
@@ -98,7 +98,7 @@ public class Utils {
     public final static String URL_SHOW = "https://hacker-news.firebaseio.com/v0/showstories.json";
     public final static String URL_JOBS = "https://hacker-news.firebaseio.com/v0/jobstories.json";
 
-    public static String adservers;
+    public static Set<String> adservers = new HashSet<>();
 
     public static void log(String s) {
         Log.d("HARMONIC_TAG", s);
@@ -138,21 +138,24 @@ public class Utils {
             @Override
             public void run() {
                 String strLine2;
-                StringBuilder adserversBuilder = new StringBuilder();
+                Set<String> adSet = new HashSet<>();
 
                 InputStream fis2 = resources.openRawResource(R.raw.adblockserverlist);
                 BufferedReader br2 = new BufferedReader(new InputStreamReader(fis2));
                 if (fis2 != null) {
                     try {
                         while ((strLine2 = br2.readLine()) != null) {
-                            adserversBuilder.append(strLine2);
-                            adserversBuilder.append("\n");
+                            if (strLine2.startsWith(":::::")) {
+                                adSet.add(strLine2.substring(5));
+                            } else {
+                                adSet.add(strLine2);
+                            }
                         }
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
                 }
-                Utils.adservers = String.valueOf(adserversBuilder);
+                Utils.adservers = adSet;
             }
         };
         AsyncTask.execute(r);


### PR DESCRIPTION
## Summary
- load adblock server list into a HashSet
- use set membership for faster adblocking checks

## Testing
- `ls app/src`

------
https://chatgpt.com/codex/tasks/task_e_68af164d64708322bb475247ceb02a28