### PR TITLE
Replace compose buttons with floating toolbar

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/ComposeActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/ComposeActivity.java
@@ -9,7 +9,6 @@ import android.text.Editable;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
@@ -30,9 +29,8 @@ import androidx.core.view.WindowInsetsAnimationCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.swiperefreshlayout.widget.CircularProgressDrawable;
 
-import com.google.android.material.button.MaterialButton;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.loadingindicator.LoadingIndicatorDrawable;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import com.simon.harmonichackernews.network.UserActions;
@@ -65,7 +63,7 @@ public class ComposeActivity extends AppCompatActivity {
     private TextInputLayout titleContainer;
     private TextInputLayout urlContainer;
     private TextInputLayout textContainer;
-    private Button submitButton;
+    private FloatingActionButton submitButton;
     private HtmlTextView replyingTextView;
     private TextView replyingHeaderTextView;
     private ScrollView replyingScrollView;
@@ -276,17 +274,17 @@ public class ComposeActivity extends AppCompatActivity {
     }
 
     public void submit(View view) {
-        MaterialButton submitButton = (MaterialButton) view;
+        FloatingActionButton submitButton = (FloatingActionButton) view;
         CircularProgressDrawable c = new CircularProgressDrawable(this);
         submitButton.setEnabled(false);
-        submitButton.setIcon(c);
+        submitButton.setImageDrawable(c);
         c.start();
 
         if (type == TYPE_POST) {
             UserActions.submit(editTextTitle.getText().toString(), editText.getText().toString(), editTextUrl.getText().toString(), view.getContext(), new UserActions.ActionCallback() {
                 @Override
                 public void onSuccess(Response response) {
-                    submitButton.setIcon(AppCompatResources.getDrawable(getApplicationContext(), R.drawable.ic_action_send));
+                    submitButton.setImageDrawable(AppCompatResources.getDrawable(getApplicationContext(), R.drawable.ic_action_send));
                     submitButton.setEnabled(true);
                     Toast.makeText(view.getContext(), "Post submitted, it might take a minute to show up", Toast.LENGTH_SHORT).show();
                     finish();
@@ -294,7 +292,7 @@ public class ComposeActivity extends AppCompatActivity {
 
                 @Override
                 public void onFailure(String summary, String response) {
-                    submitButton.setIcon(AppCompatResources.getDrawable(getApplicationContext(), R.drawable.ic_action_send));
+                    submitButton.setImageDrawable(AppCompatResources.getDrawable(getApplicationContext(), R.drawable.ic_action_send));
                     submitButton.setEnabled(true);
                     UserActions.showFailureDetailDialog(view.getContext(), summary, response);
                     Toast.makeText(view.getContext(), "Post submission unsuccessful, see dialog for details", Toast.LENGTH_SHORT).show();
@@ -306,7 +304,7 @@ public class ComposeActivity extends AppCompatActivity {
             UserActions.comment(String.valueOf(id), commentText, getApplicationContext(), new UserActions.ActionCallback() {
                 @Override
                 public void onSuccess(Response response) {
-                    submitButton.setIcon(AppCompatResources.getDrawable(getApplicationContext(), R.drawable.ic_action_send));
+                    submitButton.setImageDrawable(AppCompatResources.getDrawable(getApplicationContext(), R.drawable.ic_action_send));
                     submitButton.setEnabled(true);
                     Toast.makeText(view.getContext(), "Comment posted, it might take a minute to show up", Toast.LENGTH_SHORT).show();
                     finish();
@@ -314,7 +312,7 @@ public class ComposeActivity extends AppCompatActivity {
 
                 @Override
                 public void onFailure(String summary, String response) {
-                    submitButton.setIcon(AppCompatResources.getDrawable(getApplicationContext(), R.drawable.ic_action_send));
+                    submitButton.setImageDrawable(AppCompatResources.getDrawable(getApplicationContext(), R.drawable.ic_action_send));
                     submitButton.setEnabled(true);
                     UserActions.showFailureDetailDialog(view.getContext(), summary, response + "\n\n" + "Here is your comment should you wish to copy it and try again:\n" + commentText);
                     Toast.makeText(view.getContext(), "Comment post unsuccessful, see dialog for details", Toast.LENGTH_SHORT).show();

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -177,40 +177,51 @@
             android:layout_width="match_parent"
             android:layout_height="1dp" />
 
-        <RelativeLayout
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:paddingLeft="16dp"
             android:paddingRight="16dp"
-            android:paddingBottom="8dp"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:paddingBottom="8dp">
 
-            <Button
-                android:textSize="14dp"
-                android:fontFamily="@font/product_sans_bold"
-                android:onClick="infoClick"
+            <com.google.android.material.floatingtoolbar.FloatingToolbarLayout
+                android:id="@+id/compose_toolbar"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="?attr/storyColorNormal"
-                android:layout_toLeftOf="@id/compose_submit"
-                android:layout_marginRight="16dp"
-                style="?attr/materialButtonOutlinedStyle"
-                android:text="Formatting"/>
+                android:layout_gravity="start">
 
-            <Button
-                android:textSize="14dp"
-                android:fontFamily="@font/product_sans_bold"
+                <com.google.android.material.overflow.OverflowLinearLayout
+                    android:id="@+id/compose_toolbar_child"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <Button
+                        android:id="@+id/compose_formatting"
+                        style="@style/Widget.Material3.FloatingToolbar.IconButton"
+                        android:onClick="infoClick"
+                        android:contentDescription="Formatting info"
+                        app:icon="@drawable/ic_action_library_books" />
+
+                    <Button
+                        android:id="@+id/compose_placeholder"
+                        style="@style/Widget.Material3.FloatingToolbar.IconButton"
+                        android:contentDescription="Placeholder"
+                        app:icon="@drawable/ic_action_animation" />
+
+                </com.google.android.material.overflow.OverflowLinearLayout>
+
+            </com.google.android.material.floatingtoolbar.FloatingToolbarLayout>
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/compose_submit"
-                style="@style/Widget.Material3Expressive.Button.IconButton.Outlined"
-                app:icon="@drawable/ic_action_send"
-                app:iconTint="@color/icon_button_selector"
-                android:textColor="@color/icon_button_selector"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
+                android:layout_gravity="end"
                 android:onClick="submit"
-                android:text="Submit" />
+                app:srcCompat="@drawable/ic_action_send" />
 
-        </RelativeLayout>
+        </FrameLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,5 @@
         <item>Last week</item>
         <item>Last 24 hours</item>
     </string-array>
+
 </resources>


### PR DESCRIPTION
## Summary
- Use Material floating toolbar for compose actions with existing icons and hardcoded descriptions
- Move submit action to a FloatingActionButton
- Remove custom drawable and string resources

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68b4341eb0048322aad1f8a395b2cce4