### PR TITLE
Introduce viewbinding to simplify view references

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ android {
 
     buildFeatures {
         buildConfig = true
+        viewBinding = true
     }
 }
 

--- a/app/src/main/java/com/simon/harmonichackernews/AboutActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/AboutActivity.java
@@ -1,20 +1,17 @@
 package com.simon.harmonichackernews;
 
-
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Html;
 import android.view.View;
-import android.widget.TextView;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.graphics.Insets;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowCompat;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.simon.harmonichackernews.databinding.ActivityAboutBinding;
 import com.simon.harmonichackernews.utils.Changelog;
 import com.simon.harmonichackernews.utils.ThemeUtils;
 import com.simon.harmonichackernews.utils.Utils;
@@ -25,38 +22,19 @@ public class AboutActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        ActivityAboutBinding binding = ActivityAboutBinding.inflate(getLayoutInflater());
         ThemeUtils.setupTheme(this, false);
-        setContentView(R.layout.activity_about);
+        final View root = binding.getRoot();
+        setContentView(root);
 
         // Draw behind system bars
-        final View root = findViewById(R.id.about_root);
-        final View container = findViewById(R.id.about_container);
-
-        // Remember original paddings
-        final int padStart = container.getPaddingStart();
-        final int padTop   = container.getPaddingTop();
-        final int padEnd   = container.getPaddingEnd();
-        final int padBot   = container.getPaddingBottom();
-
-        ViewCompat.setOnApplyWindowInsetsListener(root, (v, insets) -> {
-            Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
-            Insets ime  = insets.getInsets(WindowInsetsCompat.Type.ime());
-
-            container.setPaddingRelative(
-                    padStart + bars.left,
-                    padTop   + bars.top,
-                    padEnd   + bars.right,
-                    padBot   + Math.max(bars.bottom, ime.bottom)
-            );
-            return insets; // don’t consume
-        });
-        ViewCompat.requestApplyInsets(root);
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
 
         String versionText = "Version " + BuildConfig.VERSION_NAME;
         if (BuildConfig.DEBUG) {
             versionText += String.format(" (%s)", BuildConfig.BUILD_TYPE);
         }
-        ((TextView) findViewById(R.id.about_version)).setText(versionText);
+        binding.aboutVersion.setText(versionText);
     }
 
     public void openGithub(View v) {
@@ -78,6 +56,4 @@ public class AboutActivity extends AppCompatActivity {
     public void openPrivacy(View v) {
         Utils.launchCustomTab(this, "https://simonhalvdansson.github.io/harmonic_privacy.html");
     }
-
-
 }

--- a/app/src/main/java/com/simon/harmonichackernews/MainActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/MainActivity.java
@@ -12,7 +12,6 @@ import android.widget.LinearLayout;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-
 import androidx.fragment.app.FragmentTransaction;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -106,7 +105,7 @@ public class MainActivity extends BaseActivity implements StoriesFragment.StoryC
     }
 
     private void updateFragmentLayout() {
-        if (Utils.isTablet(getResources()) && findViewById(R.id.main_fragments_container) != null) {
+        if (Utils.isTablet(getResources()) && findViewById(R.id.main_fragments_container) instanceof LinearLayout) {
             LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
                     0,
                     ViewGroup.LayoutParams.MATCH_PARENT,

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -1,202 +1,198 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/about_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
-    <ScrollView
+    <LinearLayout
+        android:paddingLeft="@dimen/single_view_side_margin"
+        android:paddingRight="@dimen/single_view_side_margin"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:paddingTop="36dp"
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
+
         <LinearLayout
-            android:id="@+id/about_container"
-            android:paddingLeft="@dimen/single_view_side_margin"
-            android:paddingRight="@dimen/single_view_side_margin"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:paddingTop="36dp"
-            android:orientation="vertical"
+            android:orientation="horizontal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
+            <ImageView
+                android:layout_gravity="center_vertical"
+                android:layout_width="56dp"
+                android:layout_height="56dp"
+                android:layout_marginRight="16dp"
+                android:src="@mipmap/ic_launcher" />
+
             <LinearLayout
-                android:orientation="horizontal"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="match_parent"
+                android:orientation="vertical">
 
-                <ImageView
-                    android:layout_gravity="center_vertical"
-                    android:layout_width="56dp"
-                    android:layout_height="56dp"
-                    android:layout_marginRight="16dp"
-                    android:src="@mipmap/ic_launcher" />
+                <TextView
+                    android:textColor="?attr/storyColorNormal"
+                    android:textStyle="bold"
+                    android:fontFamily="@font/product_sans"
+                    android:textSize="32dp"
+                    android:text="Harmonic"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:textColor="?attr/storyColorNormal"
-                        android:textStyle="bold"
-                        android:fontFamily="@font/product_sans"
-                        android:textSize="32dp"
-                        android:text="Harmonic"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"/>
-
-                    <TextView
-                        android:textColor="?attr/storyColorDisabled"
-                        android:fontFamily="@font/product_sans"
-                        android:textStyle="bold"
-                        android:id="@+id/about_version"
-                        android:layout_marginTop="-4dp"
-                        tools:text="Version 1.3.3.7"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"/>
-
-                </LinearLayout>
+                <TextView
+                    android:textColor="?attr/storyColorDisabled"
+                    android:fontFamily="@font/product_sans"
+                    android:textStyle="bold"
+                    android:id="@+id/about_version"
+                    android:layout_marginTop="-4dp"
+                    tools:text="Version 1.3.3.7"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
 
             </LinearLayout>
 
-            <TextView
-                android:paddingTop="24dp"
-                android:paddingBottom="16dp"
-                android:textSize="16sp"
-                android:fontFamily="@font/product_sans"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:text="Harmonic for Hacker News is developed by me, Simon Halvdansson, although since 2023 the app is open source. The libraries used are listed below together with Materialistic by Hidroh which I've used for some network code and PDF integration.\n\nThe name 'Harmonic' comes from me choosing to study harmonic analysis at around the time of Harmonic's inception. I guess you could say something about 'waves' and 'news' but that's the rationale. Since then, I've finished my PhD in harmonic analysis and don't have the same amount of time to work on Harmonic but it's still my favorite pet project and I use the app daily. Seeing others contribute, open meaningful issues on GitHub or just tell me they like the app is always super nice and I'm very thankful to the community for helping with the maintenance. Together I think we can keep Harmonic the (in my opinion) best Hacker News client for Android!"/>
-
-            <TextView
-                android:textColor="?attr/textColorDisabled"
-                android:text="licenses:"
-                android:paddingBottom="2dp"
-                android:fontFamily="@font/product_sans"
-                android:textStyle="bold"
-                android:textSize="13dp"
-                android:textAllCaps="true"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:fontFamily="@font/product_sans"
-                android:text="• AndroidX by Google - Apache 2.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• Volley by Google - Apache 2.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• Material Components by Google - Apache 2.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• HtmlTextView by SufficientlySecure - Apache 2.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• OkHttp by Square - Apache 2.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• Picasso by Square - Apache 2.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• Shimmer by Facebook - BSD"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• pdf.js by Mozilla - Apache 2.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• hidroh/Materialistic - Apache 2.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• jsoup - MIT"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:paddingTop="3dp"
-                android:paddingBottom="3dp"
-                android:text="• gongwen/SwipeBackLayout - Apache 2.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-            <com.google.android.material.button.MaterialButton
-                android:textSize="14sp"
-                android:layout_marginTop="16dp"
-                android:fontFamily="@font/product_sans_bold"
-                style="@style/Widget.Material3Expressive.Button.IconButton.Outlined"
-                app:icon="@drawable/ic_link_preview_github"
-                android:textColor="?attr/storyColorNormal"
-                app:iconTint="?attr/storyColorNormal"
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:onClick="openGithub"
-                android:text="Harmonic on GitHub" />
-
-            <com.google.android.material.button.MaterialButton
-                android:textSize="14sp"
-                android:fontFamily="@font/product_sans_bold"
-                style="@style/Widget.Material3Expressive.Button.IconButton.Outlined"
-                app:icon="@drawable/ic_action_update"
-                android:textColor="?attr/storyColorNormal"
-                app:iconTint="?attr/storyColorNormal"
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:onClick="openChangelog"
-                android:text="Changelog" />
-
-            <com.google.android.material.button.MaterialButton
-                android:textSize="14sp"
-                android:fontFamily="@font/product_sans_bold"
-                style="@style/Widget.Material3Expressive.Button.IconButton.Outlined"
-                app:icon="@drawable/ic_action_policy"
-                android:textColor="?attr/storyColorNormal"
-                app:iconTint="?attr/storyColorNormal"
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:onClick="openPrivacy"
-                android:text="Privacy policy" />
-
         </LinearLayout>
 
-    </ScrollView>
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:paddingTop="24dp"
+            android:paddingBottom="16dp"
+            android:textSize="16sp"
+            android:fontFamily="@font/product_sans"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="Harmonic for Hacker News is developed by me, Simon Halvdansson, although since 2023 the app is open source. The libraries used are listed below together with Materialistic by Hidroh which I've used for some network code and PDF integration.\n\nThe name 'Harmonic' comes from me choosing to study harmonic analysis at around the time of Harmonic's inception. I guess you could say something about 'waves' and 'news' but that's the rationale. Since then, I've finished my PhD in harmonic analysis and don't have the same amount of time to work on Harmonic but it's still my favorite pet project and I use the app daily. Seeing others contribute, open meaningful issues on GitHub or just tell me they like the app is always super nice and I'm very thankful to the community for helping with the maintenance. Together I think we can keep Harmonic the (in my opinion) best Hacker News client for Android!"/>
+
+        <TextView
+            android:textColor="?attr/textColorDisabled"
+            android:text="licenses:"
+            android:paddingBottom="2dp"
+            android:fontFamily="@font/product_sans"
+            android:textStyle="bold"
+            android:textSize="13dp"
+            android:textAllCaps="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:fontFamily="@font/product_sans"
+            android:text="• AndroidX by Google - Apache 2.0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• Volley by Google - Apache 2.0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• Material Components by Google - Apache 2.0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• HtmlTextView by SufficientlySecure - Apache 2.0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• OkHttp by Square - Apache 2.0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• Picasso by Square - Apache 2.0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• Shimmer by Facebook - BSD"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• pdf.js by Mozilla - Apache 2.0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• hidroh/Materialistic - Apache 2.0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• jsoup - MIT"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:paddingTop="3dp"
+            android:paddingBottom="3dp"
+            android:text="• gongwen/SwipeBackLayout - Apache 2.0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:textSize="14sp"
+            android:layout_marginTop="16dp"
+            android:fontFamily="@font/product_sans_bold"
+            style="@style/Widget.Material3Expressive.Button.IconButton.Outlined"
+            app:icon="@drawable/ic_link_preview_github"
+            android:textColor="?attr/storyColorNormal"
+            app:iconTint="?attr/storyColorNormal"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:onClick="openGithub"
+            android:text="Harmonic on GitHub" />
+
+        <com.google.android.material.button.MaterialButton
+            android:textSize="14sp"
+            android:fontFamily="@font/product_sans_bold"
+            style="@style/Widget.Material3Expressive.Button.IconButton.Outlined"
+            app:icon="@drawable/ic_action_update"
+            android:textColor="?attr/storyColorNormal"
+            app:iconTint="?attr/storyColorNormal"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:onClick="openChangelog"
+            android:text="Changelog" />
+
+        <com.google.android.material.button.MaterialButton
+            android:textSize="14sp"
+            android:fontFamily="@font/product_sans_bold"
+            style="@style/Widget.Material3Expressive.Button.IconButton.Outlined"
+            app:icon="@drawable/ic_action_policy"
+            android:textColor="?attr/storyColorNormal"
+            app:iconTint="?attr/storyColorNormal"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:onClick="openPrivacy"
+            android:text="Privacy policy" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.fragment.app.FragmentContainerView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/main_fragment_stories_container"
+    android:id="@+id/main_fragments_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:name="com.simon.harmonichackernews.StoriesFragment" />
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/main_fragment_stories_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:name="com.simon.harmonichackernews.StoriesFragment" />
+
+</FrameLayout>
+


### PR DESCRIPTION
I'm starting off with a single activity (AboutActivity) as a demonstration. This just allows avoiding a bunch of findViewById calls.

Also included:
- Cleaner edge-to-edge implementation
- Tweaking the tablet fragment container check in MainActivity since viewbinding enforces consistent root IDs
- Removing a redundant root ConstraintLayout that wasn't actually being used for any layout constraints