### PR TITLE
Enable Gradle optimizations for faster sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,18 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xms1024m -Xmx4096m
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+# Enable the parallel execution engine so configuration and task execution can
+# run across workers when Android Studio triggers Gradle Sync.
+org.gradle.parallel=true
+
+# Allow Gradle to reuse outputs from previous builds instead of re-executing
+# tasks when the inputs are unchanged. This significantly improves both sync
+# and build times after the first run.
+org.gradle.caching=true
+
+# Keep file system snapshots warm between runs so Gradle can skip expensive
+# disk scans when determining what has changed.
+org.gradle.vfs.watch=true
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true


### PR DESCRIPTION
## Summary
- enable Gradle's parallel execution to allow sync and builds to use multiple workers
- turn on the build cache and file system watching to reduce repeated work during sync

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e2a3204d148322b266c286bda09e7a