### PR TITLE
Auto-hide stories header on scroll + scroll-to-comment via URL

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -194,6 +194,7 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
     @Nullable
     private String lastRequestedWebViewUrl;
     private boolean retryingFailedWebViewUrl = false;
+    private int scrollToCommentId = -1;
 
     // Clean fallback management
     private AlgoliaFallbackManager fallbackManager;
@@ -263,6 +264,11 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
                                     story.by = "";
                                     story.url = "";
                                     story.score = 0;
+
+                                    String fragment = intent.getData().getFragment();
+                                    if (fragment != null && !fragment.isEmpty() && TextUtils.isDigitsOnly(fragment)) {
+                                        scrollToCommentId = Integer.parseInt(fragment);
+                                    }
                                 }
                             } catch (Exception e) {
                                 e.printStackTrace();
@@ -1197,6 +1203,20 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
         }
     }
 
+    private void scrollToTargetComment() {
+        if (scrollToCommentId == -1) return;
+        for (int i = 0; i < comments.size(); i++) {
+            if (comments.get(i).id == scrollToCommentId) {
+                // +1 to account for header at adapter position 0
+                layoutManager.scrollToPositionWithOffset(i + 1, 0);
+                scrollToCommentId = -1;
+                return;
+            }
+        }
+        Toast.makeText(getContext(), "Comment not found", Toast.LENGTH_SHORT).show();
+        scrollToCommentId = -1;
+    }
+
     public void destroyWebView() {
         // Nuclear
         if (webView != null) {
@@ -1327,6 +1347,7 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
                 updateNavigationVisibility();
                 adapter.notifyItemChanged(0);
                 swipeRefreshLayout.setRefreshing(false);
+                recyclerView.post(() -> scrollToTargetComment());
             }
         });
 
@@ -1515,6 +1536,7 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
 
         adapter.commentsLoaded = true;
         updateNavigationVisibility();
+        recyclerView.post(() -> scrollToTargetComment());
     }
 
     public void clickBrowser() {

--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -1208,7 +1208,7 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
         for (int i = 0; i < comments.size(); i++) {
             if (comments.get(i).id == scrollToCommentId) {
                 // +1 to account for header at adapter position 0
-                layoutManager.scrollToPositionWithOffset(i + 1, 0);
+                layoutManager.scrollToPositionWithOffset(i + 1, topInset);
                 scrollToCommentId = -1;
                 return;
             }

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -175,7 +175,12 @@ public class StoriesFragment extends Fragment {
         swipeRefreshLayout.setOnRefreshListener(this::attemptRefresh);
         ViewUtils.setUpSwipeRefreshWithStatusBarOffset(swipeRefreshLayout);
 
-        linearLayoutManager = new LinearLayoutManager(getContext());
+        linearLayoutManager = new LinearLayoutManager(getContext()) {
+            @Override
+            public boolean canScrollVertically() {
+                return !shouldLockRecyclerScroll() && super.canScrollVertically();
+            }
+        };
         recyclerView.setLayoutManager(linearLayoutManager);
 
         stories = new ArrayList<>();
@@ -412,6 +417,7 @@ public class StoriesFragment extends Fragment {
         showCachedButton.setVisibility(loadingFailed && Utils.hasCachedStories(ctx) ? View.VISIBLE : View.GONE);
 
         loadingFailedAlgoliaLayout.setVisibility(loadingFailedServerError ? View.VISIBLE : View.GONE);
+        updateRecyclerScrollState();
     }
 
     private void setupAdapter() {
@@ -968,7 +974,6 @@ public class StoriesFragment extends Fragment {
 
     private void updateSearchStatus() {
         hideUpdateButton();
-        updateHeader();
 
         if (getActivity() != null && getActivity() instanceof MainActivity) {
             ((MainActivity) getActivity()).backPressedCallback.setEnabled(searching);
@@ -984,11 +989,16 @@ public class StoriesFragment extends Fragment {
             int oldSize = stories.size();
             adapter.notifyItemRangeRemoved(0, oldSize);
             stories.clear();
+            appBarLayout.setExpanded(true, false);
         } else {
             int size = stories.size();
             stories.clear();
             adapter.notifyItemRangeRemoved(0, size);
+        }
 
+        updateHeader();
+
+        if (!searching) {
             attemptRefresh();
         }
     }
@@ -1004,7 +1014,7 @@ public class StoriesFragment extends Fragment {
     }
 
     private void loadAlgolia(String url) {
-        swipeRefreshLayout.setEnabled(true);
+        swipeRefreshLayout.setEnabled(!searching);
         swipeRefreshLayout.setRefreshing(true);
         StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
                 response -> {
@@ -1087,6 +1097,26 @@ public class StoriesFragment extends Fragment {
 
         stringRequest.setTag(requestTag);
         queue.add(stringRequest);
+    }
+
+    private boolean shouldLockRecyclerScroll() {
+        return searching && stories != null && stories.isEmpty();
+    }
+
+    private void updateRecyclerScrollState() {
+        if (recyclerView == null) {
+            return;
+        }
+
+        boolean lockRecyclerScroll = shouldLockRecyclerScroll();
+        recyclerView.setNestedScrollingEnabled(!lockRecyclerScroll);
+        recyclerView.setOverScrollMode(lockRecyclerScroll ? View.OVER_SCROLL_NEVER : View.OVER_SCROLL_IF_CONTENT_SCROLLS);
+
+        if (lockRecyclerScroll) {
+            recyclerView.stopScroll();
+            recyclerView.scrollToPosition(0);
+            appBarLayout.setExpanded(true, false);
+        }
     }
 
     public boolean currentTypeIsAlgolia() {

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -81,7 +81,6 @@ public class StoriesFragment extends Fragment {
     private ExtendedFloatingActionButton updateFab;
     private RecyclerView recyclerView;
     private AppBarLayout appBarLayout;
-    private View headerSeparator;
 
     // Header views
     private LinearLayout headerContainer;
@@ -153,7 +152,6 @@ public class StoriesFragment extends Fragment {
                 headerContainer.setAlpha(1f - (Math.abs(verticalOffset) / totalScrollRange));
             }
         });
-        headerSeparator = view.findViewById(R.id.stories_header_separator);
 
         // Bind header views
         headerContainer = view.findViewById(R.id.stories_header_container);
@@ -247,11 +245,6 @@ public class StoriesFragment extends Fragment {
                         loadStory(stories.get(i), 0);
                     }
                 }
-
-                // Fade separator based on scroll offset
-                int offset = recyclerView.computeVerticalScrollOffset();
-                float separatorAlpha = Math.min(offset / 150f, 1f);
-                headerSeparator.setAlpha(separatorAlpha);
             }
         });
 

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -15,13 +16,23 @@ import android.view.ViewGroup;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.PathInterpolator;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ImageButton;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
+import android.widget.Spinner;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.PopupMenu;
+import androidx.appcompat.widget.TooltipCompat;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.graphics.Insets;
 import androidx.core.view.OnApplyWindowInsetsListener;
@@ -35,6 +46,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.StringRequest;
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
 import com.simon.harmonichackernews.adapters.StoryRecyclerViewAdapter;
 import com.simon.harmonichackernews.data.Bookmark;
@@ -68,6 +80,25 @@ public class StoriesFragment extends Fragment {
     private SwipeRefreshLayout swipeRefreshLayout;
     private ExtendedFloatingActionButton updateFab;
     private RecyclerView recyclerView;
+    private AppBarLayout appBarLayout;
+    private View headerSeparator;
+
+    // Header views
+    private LinearLayout headerContainer;
+    private Spinner typeSpinner;
+    private LinearLayout spinnerContainer;
+    private EditText searchEditText;
+    private ImageButton searchButton;
+    private ImageButton moreButton;
+    private RelativeLayout loadingIndicator;
+    private LinearLayout loadingFailedLayout;
+    private TextView loadingFailedText;
+    private TextView loadingFailedAlgoliaLayout;
+    private LinearLayout noBookmarksLayout;
+    private TextView showingCachedText;
+    private LinearLayout searchEmptyContainer;
+    private Button retryButton;
+    private Button showCachedButton;
 
     private StoryRecyclerViewAdapter adapter;
     private List<Story> stories;
@@ -77,11 +108,14 @@ public class StoriesFragment extends Fragment {
     private ArrayList<String> filterWords;
     private ArrayList<String> filterDomains;
     private boolean hideJobs, alwaysOpenComments, hideClicked;
-    private String lastSearch;
+    private boolean searching = false;
+    private boolean loadingFailed = false;
+    private boolean loadingFailedServerError = false;
+    private String lastSearch = "";
 
     public static boolean showingCached = false;
 
-    private int loadedTo = 0;
+    private int loadedTo = -1;
     private boolean paginationMode = false;
     private static final int PAGINATION_PAGE_SIZE = 30;
 
@@ -112,6 +146,31 @@ public class StoriesFragment extends Fragment {
         recyclerView = view.findViewById(R.id.stories_recyclerview);
         swipeRefreshLayout = view.findViewById(R.id.stories_swipe_refresh);
         updateFab = view.findViewById(R.id.stories_update_fab);
+        appBarLayout = view.findViewById(R.id.stories_appbar);
+        appBarLayout.addOnOffsetChangedListener((appBar, verticalOffset) -> {
+            float totalScrollRange = appBar.getTotalScrollRange();
+            if (totalScrollRange > 0) {
+                headerContainer.setAlpha(1f - (Math.abs(verticalOffset) / totalScrollRange));
+            }
+        });
+        headerSeparator = view.findViewById(R.id.stories_header_separator);
+
+        // Bind header views
+        headerContainer = view.findViewById(R.id.stories_header_container);
+        typeSpinner = view.findViewById(R.id.stories_header_spinner);
+        spinnerContainer = view.findViewById(R.id.stories_header_spinner_container);
+        searchEditText = view.findViewById(R.id.stories_header_search_edittext);
+        searchButton = view.findViewById(R.id.stories_header_search_button);
+        moreButton = view.findViewById(R.id.stories_header_more);
+        loadingIndicator = view.findViewById(R.id.stories_header_loading_indicator);
+        loadingFailedLayout = view.findViewById(R.id.stories_header_loading_failed);
+        loadingFailedText = view.findViewById(R.id.stories_header_loading_failed_text);
+        loadingFailedAlgoliaLayout = view.findViewById(R.id.stories_header_loading_failed_algolia);
+        noBookmarksLayout = view.findViewById(R.id.stories_header_no_bookmarks);
+        showingCachedText = view.findViewById(R.id.stories_header_cached_stories_header);
+        searchEmptyContainer = view.findViewById(R.id.stories_header_search_empty_container);
+        retryButton = view.findViewById(R.id.stories_header_retry_button);
+        showCachedButton = view.findViewById(R.id.stories_header_show_cached);
 
         swipeRefreshLayout.setOnRefreshListener(this::attemptRefresh);
         ViewUtils.setUpSwipeRefreshWithStatusBarOffset(swipeRefreshLayout);
@@ -123,6 +182,9 @@ public class StoriesFragment extends Fragment {
         setupAdapter();
         recyclerView.setAdapter(adapter);
 
+        // Setup header after adapter so spinner callback can safely access adapter.type
+        setupHeader();
+
         ViewCompat.setOnApplyWindowInsetsListener(view, new OnApplyWindowInsetsListener() {
             @NonNull
             @Override
@@ -133,7 +195,23 @@ public class StoriesFragment extends Fragment {
                 params.bottomMargin = insets.bottom + Utils.pxFromDpInt(getResources(), 8);
                 updateFab.setLayoutParams(params);
 
+
                 topInset = insets.top;
+
+                // Apply top inset to header container
+                boolean compactHeader = SettingsUtils.shouldUseCompactHeader(getContext());
+                int topPad = insets.top + Utils.pxFromDpInt(getResources(), compactHeader ? 20 : 40);
+                int bottomPad = Utils.pxFromDpInt(getResources(), compactHeader ? 10 : 26);
+                int sidePad = Utils.pxFromDpInt(getResources(), 16);
+                headerContainer.setPadding(sidePad, topPad, sidePad, bottomPad);
+
+                // Apply bottom inset to RecyclerView so last item isn't behind nav bar
+                recyclerView.setPadding(
+                        recyclerView.getPaddingLeft(),
+                        recyclerView.getPaddingTop(),
+                        recyclerView.getPaddingRight(),
+                        insets.bottom
+                );
 
                 return windowInsets;
             }
@@ -154,7 +232,7 @@ public class StoriesFragment extends Fragment {
                 super.onScrolled(recyclerView, dx, dy);
 
                 // Only enable infinite scroll if pagination mode is OFF
-                if (!adapter.searching && !paginationMode) {
+                if (!searching && !paginationMode) {
                     lastVisibleItem = linearLayoutManager.findLastVisibleItemPosition();
 
                     int visibleThreshold = 17;
@@ -164,17 +242,21 @@ public class StoriesFragment extends Fragment {
                         loadStory(stories.get(i), 0);
                     }
                 }
+
+                // Fade separator based on scroll offset
+                int offset = recyclerView.computeVerticalScrollOffset();
+                float separatorAlpha = Math.min(offset / 150f, 1f);
+                headerSeparator.setAlpha(separatorAlpha);
             }
         });
 
         queue = NetworkComponent.getRequestQueueInstance(requireContext());
-        stories.add(new Story());
         attemptRefresh();
 
         StoryUpdate.setStoryUpdatedListener(new StoryUpdate.StoryUpdateListener() {
             @Override
             public void callback(Story story) {
-                for (int i = 1; i < stories.size(); i++) {
+                for (int i = 0; i < stories.size(); i++) {
                     if (story.id == stories.get(i).id) {
                         Story oldStory = stories.get(i);
 
@@ -200,6 +282,137 @@ public class StoriesFragment extends Fragment {
         return typeAdapterList.indexOf(SettingsUtils.getPreferredStoryType(getContext()));
     }
 
+    private void setupHeader() {
+        final Context ctx = requireContext();
+
+        // Tap empty header area to scroll to top
+        headerContainer.setOnClickListener(v -> {
+            recyclerView.smoothScrollToPosition(0);
+            appBarLayout.setExpanded(true, true);
+        });
+
+        // Set up retry button
+        retryButton.setOnClickListener(v -> attemptRefresh());
+        showCachedButton.setOnClickListener(v -> showCachedStories());
+
+        // Set up more button
+        moreButton.setOnClickListener(this::moreClick);
+
+        // Set up search
+        searchEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView textView, int actionId, KeyEvent keyEvent) {
+                boolean isKeyboardSearchAction = actionId == EditorInfo.IME_ACTION_SEARCH;
+                boolean isHardwareEnterKey = keyEvent != null
+                        && keyEvent.getKeyCode() == KeyEvent.KEYCODE_ENTER
+                        && keyEvent.getAction() == KeyEvent.ACTION_DOWN;
+
+                if (!isKeyboardSearchAction && !isHardwareEnterKey) {
+                    return false;
+                }
+
+                search(searchEditText.getText().toString());
+                if (textView != null) {
+                    InputMethodManager imm = (InputMethodManager) ctx.getSystemService(Context.INPUT_METHOD_SERVICE);
+                    imm.hideSoftInputFromWindow(textView.getWindowToken(), 0);
+                }
+                return true;
+            }
+        });
+
+        searchButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                searching = !searching;
+                updateSearchStatus();
+
+                InputMethodManager imm = (InputMethodManager) ctx.getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (searching) {
+                    imm.toggleSoftInput(InputMethodManager.SHOW_IMPLICIT, 0);
+                } else {
+                    imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+                    lastSearch = "";
+                }
+            }
+        });
+
+        // Set up spinner
+        String[] sortingOptions = ctx.getResources().getStringArray(R.array.sorting_options);
+        ArrayList<CharSequence> typeAdapterList = new ArrayList<>(Arrays.asList(sortingOptions));
+        ArrayAdapter<CharSequence> spinnerAdapter = new ArrayAdapter<>(ctx, R.layout.spinner_top_layout, R.id.selection_dropdown_item_textview, typeAdapterList);
+        spinnerAdapter.setDropDownViewResource(R.layout.spinner_item_layout);
+
+        typeSpinner.setAdapter(spinnerAdapter);
+        typeSpinner.setSelection(getPreferredTypeIndex());
+        typeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                if (i != adapter.type) {
+                    adapter.type = i;
+                    attemptRefresh();
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+            }
+        });
+    }
+
+    private void updateHeader() {
+        if (headerContainer == null) return;
+
+        Context ctx = getContext();
+        if (ctx == null) return;
+
+        boolean compactHeader = SettingsUtils.shouldUseCompactHeader(ctx);
+        int topPad = topInset + Utils.pxFromDpInt(getResources(), compactHeader ? 20 : 40);
+        int bottomPad = Utils.pxFromDpInt(getResources(), compactHeader ? 10 : 26);
+        int sidePad = Utils.pxFromDpInt(getResources(), 16);
+        headerContainer.setPadding(sidePad, topPad, sidePad, bottomPad);
+
+        moreButton.setVisibility(searching ? View.GONE : View.VISIBLE);
+        spinnerContainer.setVisibility(searching ? View.GONE : View.VISIBLE);
+
+        searchButton.setImageResource(searching ? R.drawable.ic_action_cancel : R.drawable.ic_action_search);
+
+        searchEditText.setVisibility(searching ? View.VISIBLE : View.GONE);
+
+        if (searching) {
+            loadingIndicator.setVisibility(View.GONE);
+            searchEditText.requestFocus();
+            searchEditText.setText(lastSearch);
+            searchEditText.setSelection(lastSearch.length());
+
+            searchEmptyContainer.setVisibility(stories.isEmpty() ? View.VISIBLE : View.GONE);
+            noBookmarksLayout.setVisibility(View.GONE);
+        } else {
+            noBookmarksLayout.setVisibility((stories.isEmpty() && adapter.type == SettingsUtils.getBookmarksIndex(ctx.getResources())) ? View.VISIBLE : View.GONE);
+            searchEmptyContainer.setVisibility(View.GONE);
+
+            loadingIndicator.setVisibility(stories.isEmpty() && !loadingFailed && !loadingFailedServerError && (adapter.type != SettingsUtils.getBookmarksIndex(ctx.getResources())) ? View.VISIBLE : View.GONE);
+        }
+
+        showingCachedText.setVisibility(showingCached && !searching ? View.VISIBLE : View.GONE);
+
+        typeSpinner.setSelection(adapter.type);
+
+        TooltipCompat.setTooltipText(searchButton, searching ? "Close" : "Search");
+        TooltipCompat.setTooltipText(moreButton, "More");
+
+        loadingFailedLayout.setVisibility(loadingFailed ? View.VISIBLE : View.GONE);
+        if (loadingFailed) {
+            if (!Utils.isNetworkAvailable(ctx)) {
+                loadingFailedText.setText("No internet connection");
+            } else {
+                loadingFailedText.setText("Loading failed");
+            }
+        }
+
+        showCachedButton.setVisibility(loadingFailed && Utils.hasCachedStories(ctx) ? View.VISIBLE : View.GONE);
+
+        loadingFailedAlgoliaLayout.setVisibility(loadingFailedServerError ? View.VISIBLE : View.GONE);
+    }
 
     private void setupAdapter() {
         paginationMode = SettingsUtils.shouldUsePaginationMode(getContext());
@@ -262,9 +475,6 @@ public class StoriesFragment extends Fragment {
         });
 
         adapter.setOnCommentClickListener(this::clickedComments);
-        adapter.setOnRefreshListener(this::attemptRefresh);
-        adapter.setOnMoreClickListener(this::moreClick);
-        adapter.setOnShowCachedListener(this::showCachedStories);
 
         // Set up pagination "Load More" button click listener
         adapter.setOnLoadMoreClickListener(v -> {
@@ -284,26 +494,6 @@ public class StoriesFragment extends Fragment {
 
                 // Update adapter to show more items
                 adapter.loadNextPage();
-            }
-        });
-
-        adapter.setOnTypeClickListener(index -> {
-            if (index != adapter.type) {
-                adapter.type = index;
-                attemptRefresh();
-            }
-        });
-
-        adapter.setSearchListener(new StoryRecyclerViewAdapter.SearchListener() {
-            @Override
-            public void onQueryTextSubmit(String query) {
-                search(query);
-
-            }
-
-            @Override
-            public void onSearchStatusChanged() {
-                updateSearchStatus();
             }
         });
 
@@ -410,33 +600,33 @@ public class StoriesFragment extends Fragment {
         long timeDiff = System.currentTimeMillis() - lastLoaded;
 
         // if more than 1 hr
-        if (timeDiff > 1000 * 60 * 60 && !adapter.searching && adapter.type != SettingsUtils.getBookmarksIndex(getResources()) && !currentTypeIsAlgolia()) {
+        if (timeDiff > 1000 * 60 * 60 && !searching && adapter.type != SettingsUtils.getBookmarksIndex(getResources()) && !currentTypeIsAlgolia()) {
             showUpdateButton();
         }
 
         if (adapter.showPoints != SettingsUtils.shouldShowPoints(getContext())) {
             adapter.showPoints = !adapter.showPoints;
-            adapter.notifyItemRangeChanged(1, stories.size());
+            adapter.notifyItemRangeChanged(0, stories.size());
         }
 
         if (adapter.showCommentsCount != SettingsUtils.shouldShowCommentsCount(getContext())) {
             adapter.showCommentsCount = !adapter.showCommentsCount;
-            adapter.notifyItemRangeChanged(1, stories.size());
+            adapter.notifyItemRangeChanged(0, stories.size());
         }
 
         if (adapter.compactView != SettingsUtils.shouldUseCompactView(getContext())) {
             adapter.compactView = !adapter.compactView;
-            adapter.notifyItemRangeChanged(1, stories.size());
+            adapter.notifyItemRangeChanged(0, stories.size());
         }
 
         if (adapter.thumbnails != SettingsUtils.shouldShowThumbnails(getContext())) {
             adapter.thumbnails = !adapter.thumbnails;
-            adapter.notifyItemRangeChanged(1, stories.size());
+            adapter.notifyItemRangeChanged(0, stories.size());
         }
 
         if (adapter.showIndex != SettingsUtils.shouldShowIndex(getContext())) {
             adapter.showIndex = !adapter.showIndex;
-            adapter.notifyItemRangeChanged(1, stories.size());
+            adapter.notifyItemRangeChanged(0, stories.size());
         }
 
         if (adapter.leftAlign != SettingsUtils.shouldUseLeftAlign(getContext())) {
@@ -460,12 +650,12 @@ public class StoriesFragment extends Fragment {
 
         if (adapter.compactHeader != SettingsUtils.shouldUseCompactHeader(getContext())) {
             adapter.compactHeader = SettingsUtils.shouldUseCompactHeader(getContext());
-            adapter.notifyItemChanged(0);
+            updateHeader();
         }
 
         if (adapter.hotness != SettingsUtils.getPreferredHotness(getContext())) {
             adapter.hotness = SettingsUtils.getPreferredHotness(getContext());
-            adapter.notifyItemRangeChanged(1, stories.size());
+            adapter.notifyItemRangeChanged(0, stories.size());
         }
 
         if (hideJobs != SettingsUtils.shouldHideJobs(getContext())) {
@@ -475,7 +665,7 @@ public class StoriesFragment extends Fragment {
 
         if (adapter.faviconProvider != SettingsUtils.getPreferredFaviconProvider(getContext())) {
             adapter.faviconProvider = SettingsUtils.getPreferredFaviconProvider(getContext());
-            adapter.notifyItemRangeChanged(1, stories.size());
+            adapter.notifyItemRangeChanged(0, stories.size());
         }
 
     }
@@ -527,7 +717,7 @@ public class StoriesFragment extends Fragment {
                         if (!JSONParser.updateStoryWithHNJson(response, story, adapter.type == SettingsUtils.getHistoryIndex(getResources()))) {
                             stories.remove(story);
                             adapter.notifyItemRemoved(index);
-                            loadedTo = Math.max(0, loadedTo - 1);
+                            loadedTo = Math.max(-1, loadedTo - 1);
                             return;
                         }
 
@@ -536,7 +726,7 @@ public class StoriesFragment extends Fragment {
                             if (story.title.toLowerCase().contains(phrase.toLowerCase())) {
                                 stories.remove(story);
                                 adapter.notifyItemRemoved(index);
-                                loadedTo = Math.max(0, loadedTo - 1);
+                                loadedTo = Math.max(-1, loadedTo - 1);
                                 return;
                             }
                         }
@@ -549,7 +739,7 @@ public class StoriesFragment extends Fragment {
 
                                     stories.remove(story);
                                     adapter.notifyItemRemoved(index);
-                                    loadedTo = Math.max(0, loadedTo - 1);
+                                    loadedTo = Math.max(-1, loadedTo - 1);
                                     return;
                                 }
                             } catch (Exception e) {
@@ -561,7 +751,7 @@ public class StoriesFragment extends Fragment {
                         if (hideJobs && adapter.type != SettingsUtils.getJobsIndex(getResources()) && (story.isJob || story.by.equals("whoishiring"))) {
                             stories.remove(story);
                             adapter.notifyItemRemoved(index);
-                            loadedTo = Math.max(0, loadedTo - 1);
+                            loadedTo = Math.max(-1, loadedTo - 1);
                             return;
                         }
 
@@ -631,7 +821,7 @@ public class StoriesFragment extends Fragment {
 
     public void attemptRefresh() {
         hideUpdateButton();
-        if (adapter.searching) {
+        if (searching) {
             search(lastSearch);
             return;
         }
@@ -662,11 +852,11 @@ public class StoriesFragment extends Fragment {
 
         if (adapter.type == SettingsUtils.getBookmarksIndex(getResources())) {
             // lets load bookmarks instead - or rather add empty stories with correct id:s and start loading them
-            adapter.notifyItemRangeRemoved(1, stories.size() + 1);
-            loadedTo = 0;
+            int oldSize = stories.size();
+            adapter.notifyItemRangeRemoved(0, oldSize);
+            loadedTo = -1;
 
             stories.clear();
-            stories.add(new Story());
             showingCached = false;
 
             ArrayList<Bookmark> bookmarks = Utils.loadBookmarks(getContext(), true);
@@ -675,24 +865,24 @@ public class StoriesFragment extends Fragment {
                 Story s = new Story("Loading...", bookmarks.get(i).id, false, false);
 
                 stories.add(s);
-                adapter.notifyItemInserted(i + 1);
+                adapter.notifyItemInserted(i);
                 int initialLoadCount = paginationMode ? PAGINATION_PAGE_SIZE : 20;
                 if (i < initialLoadCount) {
-                    loadStory(stories.get(i + 1), 0);
-                    loadedTo = i + 1;
+                    loadStory(stories.get(i), 0);
+                    loadedTo = i;
                 }
             }
 
-            adapter.notifyItemChanged(0);
+            updateHeader();
             swipeRefreshLayout.setRefreshing(false);
 
             return;
         } else if (adapter.type == SettingsUtils.getHistoryIndex(getResources())) {
-            adapter.notifyItemRangeRemoved(1, stories.size() + 1);
-            loadedTo = 0;
+            int oldSize = stories.size();
+            adapter.notifyItemRangeRemoved(0, oldSize);
+            loadedTo = -1;
 
             stories.clear();
-            stories.add(new Story());
             showingCached = false;
             List<History> histories = UtilsKt.INSTANCE.loadHistories(requireContext(), true);
 
@@ -700,15 +890,15 @@ public class StoriesFragment extends Fragment {
                 Story s = new Story("Loading...", histories.get(i).getId(), false, false, histories.get(i).getCreated());
 
                 stories.add(s);
-                adapter.notifyItemInserted(i + 1);
+                adapter.notifyItemInserted(i);
                 int initialLoadCount = paginationMode ? PAGINATION_PAGE_SIZE : 20;
                 if (i < initialLoadCount) {
-                    loadStory(stories.get(i + 1), 0);
-                    loadedTo = i + 1;
+                    loadStory(stories.get(i), 0);
+                    loadedTo = i;
                 }
             }
 
-            adapter.notifyItemChanged(0);
+            updateHeader();
             swipeRefreshLayout.setRefreshing(false);
 
             return;
@@ -721,12 +911,12 @@ public class StoriesFragment extends Fragment {
                     try {
                         JSONArray jsonArray = new JSONArray(response);
 
-                        loadedTo = 0;
+                        loadedTo = -1;
 
-                        adapter.notifyItemRangeRemoved(1, stories.size());
+                        int oldSize = stories.size();
+                        adapter.notifyItemRangeRemoved(0, oldSize);
 
                         stories.clear();
-                        stories.add(new Story());
                         showingCached = false;
 
                         for (int i = 0; i < jsonArray.length(); i++) {
@@ -744,20 +934,20 @@ public class StoriesFragment extends Fragment {
                             }
 
                             stories.add(s);
-                            adapter.notifyItemInserted(1 + i);
+                            adapter.notifyItemInserted(stories.size() - 1);
                         }
 
-                        if (adapter.loadingFailed) {
-                            adapter.loadingFailed = false;
-                            adapter.loadingFailedServerError = false;
+                        if (loadingFailed) {
+                            loadingFailed = false;
+                            loadingFailedServerError = false;
                         }
 
-                        adapter.notifyItemChanged(0);
+                        updateHeader();
 
                         // Load initial batch of stories
                         int initialLoadCount = paginationMode ? PAGINATION_PAGE_SIZE : 20;
-                        int storiesToLoad = Math.min(initialLoadCount, stories.size() - 1);
-                        for (int i = 1; i <= storiesToLoad; i++) {
+                        int storiesToLoad = Math.min(initialLoadCount, stories.size());
+                        for (int i = 0; i < storiesToLoad; i++) {
                             loadedTo = i;
                             loadStory(stories.get(i), 0);
                         }
@@ -767,39 +957,37 @@ public class StoriesFragment extends Fragment {
                     }
                 }, error -> {
             swipeRefreshLayout.setRefreshing(false);
-            adapter.loadingFailed = true;
-            adapter.notifyItemChanged(0);
+            loadingFailed = true;
+            updateHeader();
         });
 
-        adapter.notifyItemChanged(0);
+        updateHeader();
         stringRequest.setTag(requestTag);
         queue.add(stringRequest);
     }
 
     private void updateSearchStatus() {
         hideUpdateButton();
-        adapter.notifyItemChanged(0);
+        updateHeader();
 
         if (getActivity() != null && getActivity() instanceof MainActivity) {
-            ((MainActivity) getActivity()).backPressedCallback.setEnabled(adapter.searching);
+            ((MainActivity) getActivity()).backPressedCallback.setEnabled(searching);
         }
 
-        swipeRefreshLayout.setEnabled(!adapter.searching);
+        swipeRefreshLayout.setEnabled(!searching);
 
-        if (adapter.searching) {
+        if (searching) {
             // cancel all ongoing
             queue.cancelAll(requestTag);
             swipeRefreshLayout.setRefreshing(false);
 
-            adapter.notifyItemRangeRemoved(1, stories.size() + 1);
+            int oldSize = stories.size();
+            adapter.notifyItemRangeRemoved(0, oldSize);
             stories.clear();
-            stories.add(new Story());
         } else {
             int size = stories.size();
-            if (size > 1) {
-                stories.subList(1, size).clear();
-            }
-            adapter.notifyItemRangeRemoved(1, size + 1);
+            stories.clear();
+            adapter.notifyItemRangeRemoved(0, size);
 
             attemptRefresh();
         }
@@ -811,7 +999,6 @@ public class StoriesFragment extends Fragment {
 
     private void search(String query) {
         lastSearch = query;
-        adapter.lastSearch = query;
 
         loadAlgolia("https://hn.algolia.com/api/v1/search_by_date?query=" + query + "&tags=story&hitsPerPage=200&typoTolerance=min");
     }
@@ -830,10 +1017,9 @@ public class StoriesFragment extends Fragment {
                             int oldSize = stories.size();
 
                             stories.clear();
-                            stories.add(new Story());
                             showingCached = false;
 
-                            adapter.notifyItemRangeRemoved(1, oldSize + 1);
+                            adapter.notifyItemRangeRemoved(0, oldSize);
 
                             stories.addAll(parsedStories);
 
@@ -868,12 +1054,12 @@ public class StoriesFragment extends Fragment {
                                 }
                             }
 
-                            adapter.loadingFailed = false;
-                            adapter.loadingFailedServerError = false;
+                            loadingFailed = false;
+                            loadingFailedServerError = false;
                             showingCached = false;
 
-                            adapter.notifyItemRangeInserted(1, stories.size());
-                            adapter.notifyItemChanged(0);
+                            adapter.notifyItemRangeInserted(0, stories.size());
+                            updateHeader();
 
                             // Set loadedTo for Algolia stories (they're already fully loaded)
                             loadedTo = stories.size() - 1;
@@ -888,16 +1074,16 @@ public class StoriesFragment extends Fragment {
 
                 }, error -> {
             if (error.networkResponse != null && error.networkResponse.statusCode == 404) {
-                adapter.loadingFailedServerError = true;
+                loadingFailedServerError = true;
             }
 
             error.printStackTrace();
             swipeRefreshLayout.setRefreshing(false);
-            adapter.loadingFailed = true;
-            adapter.notifyItemChanged(0);
+            loadingFailed = true;
+            updateHeader();
         });
 
-        adapter.notifyItemChanged(0);
+        updateHeader();
 
         stringRequest.setTag(requestTag);
         queue.add(stringRequest);
@@ -908,9 +1094,9 @@ public class StoriesFragment extends Fragment {
     }
 
     public boolean exitSearch() {
-        if (adapter.searching) {
-            adapter.searching = false;
-            adapter.lastSearch = "";
+        if (searching) {
+            searching = false;
+            lastSearch = "";
             updateSearchStatus();
             return true;
         }
@@ -944,14 +1130,15 @@ public class StoriesFragment extends Fragment {
         showingCached = true;
         swipeRefreshLayout.setRefreshing(false);
 
-        adapter.notifyItemRangeRemoved(1, stories.size());
+        int oldSize = stories.size();
         stories.clear();
-        stories.add(new Story());
         stories.addAll(Utils.loadCachedStories(getContext()));
         loadedTo = stories.size() - 1;
-        adapter.loadingFailed = false;
-        adapter.loadingFailedServerError = false;
-        adapter.notifyItemRangeChanged(0, stories.size());
+        loadingFailed = false;
+        loadingFailedServerError = false;
+        adapter.notifyItemRangeRemoved(0, oldSize);
+        adapter.notifyItemRangeInserted(0, stories.size());
+        updateHeader();
     }
 
     private void hideUpdateButton() {

--- a/app/src/main/java/com/simon/harmonichackernews/SubmissionsActivity.java
+++ b/app/src/main/java/com/simon/harmonichackernews/SubmissionsActivity.java
@@ -74,7 +74,6 @@ public class SubmissionsActivity extends AppCompatActivity {
                 getIntent().getStringExtra(KEY_USER),
                 -1);
 
-        adapter.setOnRefreshListener(this::loadSubmissions);
         adapter.setOnCommentClickListener(new StoryRecyclerViewAdapter.ClickListener() {
             @Override
             public void onItemClick(int position) {
@@ -172,11 +171,7 @@ public class SubmissionsActivity extends AppCompatActivity {
 
                             submissions.addAll(parsedStories);
 
-                            adapter.loadingFailed = false;
-                            adapter.loadingFailedServerError = false;
-
                             adapter.notifyItemRangeInserted(1, submissions.size());
-                            adapter.notifyItemChanged(0);
                         }
 
                         @Override
@@ -187,14 +182,8 @@ public class SubmissionsActivity extends AppCompatActivity {
                     });
 
                 }, error -> {
-            if (error.networkResponse != null && error.networkResponse.statusCode == 404) {
-                adapter.loadingFailedServerError = true;
-            }
-
             error.printStackTrace();
             swipeRefreshLayout.setRefreshing(false);
-            adapter.loadingFailed = true;
-            adapter.notifyItemChanged(0);
         });
 
         queue.add(stringRequest);

--- a/app/src/main/java/com/simon/harmonichackernews/adapters/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/com/simon/harmonichackernews/adapters/StoryRecyclerViewAdapter.java
@@ -9,31 +9,20 @@ import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.ImageSpan;
 import android.util.TypedValue;
-import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputMethodManager;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
 import android.widget.Button;
-import android.widget.EditText;
-import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
-import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.simon.harmonichackernews.R;
-import com.simon.harmonichackernews.StoriesFragment;
 import com.simon.harmonichackernews.data.Story;
 import com.simon.harmonichackernews.network.FaviconLoader;
 import com.simon.harmonichackernews.utils.FontUtils;
@@ -46,35 +35,24 @@ import org.jetbrains.annotations.NotNull;
 import org.sufficientlysecure.htmltextview.HtmlTextView;
 import org.sufficientlysecure.htmltextview.OnClickATagListener;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     private final List<Story> stories;
-    private ClickListener typeClickListener;
     private ClickListener linkClickListener;
     private ClickListener commentClickListener;
     private ClickListener commentRepliesClickListener;
     private ClickListener commentStoryClickListener;
-    private SearchListener storiesSearchListener;
-    private RefreshListener refreshListener;
-    private CachedListener cachedListener;
-    private View.OnClickListener moreClickListener;
     private View.OnClickListener loadMoreClickListener;
     private LongClickCoordinateListener longClickListener;
     private final boolean atSubmissions;
     private final String submitter;
 
-    private static final int TYPE_HEADER_MAIN = 0;
     private static final int TYPE_HEADER_SUBMISSIONS = 1;
     private static final int TYPE_STORY = 2;
     private static final int TYPE_COMMENT = 3;
     private static final int TYPE_LOAD_MORE_BUTTON = 4;
-
-    public boolean loadingFailed = false;
-    public boolean loadingFailedServerError = false;
 
     public boolean showPoints;
     public boolean showCommentsCount;
@@ -86,13 +64,10 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
     public String faviconProvider;
     public int hotness;
     public int type;
-    public boolean searching = false;
 
     public boolean paginationMode = false;
     public static final int PAGINATION_PAGE_SIZE = 30;
     public int visibleStoryCount = 30;
-
-    public String lastSearch = "";
 
     public StoryRecyclerViewAdapter(List<Story> items,
                                     boolean shouldShowPoints,
@@ -127,8 +102,6 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
     public RecyclerView.ViewHolder onCreateViewHolder(@NotNull ViewGroup parent, int viewType) {
         if (viewType == TYPE_STORY) {
             return new StoryViewHolder(LayoutInflater.from(parent.getContext()).inflate(leftAlign ? R.layout.story_list_item_left : R.layout.story_list_item, parent, false));
-        } else if (viewType == TYPE_HEADER_MAIN) {
-            return new MainHeaderViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.stories_header, parent, false));
         } else if (viewType == TYPE_HEADER_SUBMISSIONS) {
             return new SubmissionsHeaderViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.submissions_header, parent, false));
         } else if (viewType == TYPE_LOAD_MORE_BUTTON) {
@@ -143,8 +116,6 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
     public void onBindViewHolder(@NotNull final RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof LoadMoreViewHolder) {
             LoadMoreViewHolder loadMoreHolder = (LoadMoreViewHolder) holder;
-            // stories[0] is header, actual story count = stories.size() - 1
-            int remainingStories = (stories.size() - 1) - visibleStoryCount;
 
             loadMoreHolder.loadMoreButton.setOnClickListener(v -> {
                 if (loadMoreClickListener != null) {
@@ -158,12 +129,13 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
             final StoryViewHolder storyViewHolder = (StoryViewHolder) holder;
             final Context ctx = storyViewHolder.itemView.getContext();
 
-            // Position 0 is header (handled separately), positions 1+ are stories
-            // stories[0] is empty header, stories[1+] are actual stories
-            // So adapter position N maps to stories[N]
             storyViewHolder.story = stories.get(position);
+
             if (showIndex) {
-                storyViewHolder.indexTextView.setText(position + ".");
+                // For submissions, position 0 is header so story index = position
+                // For non-submissions, position 0 is first story so display index = position + 1
+                int displayIndex = atSubmissions ? position : position + 1;
+                storyViewHolder.indexTextView.setText(displayIndex + ".");
 
                 if (storyViewHolder.story.clicked) {
                     storyViewHolder.indexTextView.setTextColor(Utils.getColorViaAttr(ctx, R.attr.storyColorDisabled));
@@ -171,7 +143,7 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
                     storyViewHolder.indexTextView.setTextColor(Utils.getColorViaAttr(ctx, R.attr.storyColorNormal));
                 }
 
-                if (position < 100) {
+                if (displayIndex < 100) {
                     storyViewHolder.indexTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 16);
                     storyViewHolder.indexTextView.setPadding(0, Utils.pxFromDpInt(ctx.getResources(), 0.5f), 0, 0);
                 } else {
@@ -270,58 +242,6 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
                 storyViewHolder.commentLayoutView.setClickable(false);
                 storyViewHolder.commentsIcon.setAlpha(storyViewHolder.story.clicked ? 0.6f : 1.0f);
             }
-        } else if (holder instanceof MainHeaderViewHolder) {
-            final MainHeaderViewHolder headerViewHolder = (MainHeaderViewHolder) holder;
-            final Context ctx = headerViewHolder.itemView.getContext();
-
-            if (compactHeader) {
-                headerViewHolder.container.setPadding(0, Utils.pxFromDpInt(ctx.getResources(), 20), 0, Utils.pxFromDpInt(ctx.getResources(), 10));
-            } else {
-                headerViewHolder.container.setPadding(0, Utils.pxFromDpInt(ctx.getResources(), 40), 0, Utils.pxFromDpInt(ctx.getResources(), 26));
-            }
-
-            headerViewHolder.moreButton.setVisibility(searching ? View.GONE : View.VISIBLE);
-            headerViewHolder.spinnerContainer.setVisibility(searching ? View.GONE : View.VISIBLE);
-
-            headerViewHolder.searchButton.setImageResource(searching ? R.drawable.ic_action_cancel : R.drawable.ic_action_search);
-
-            headerViewHolder.searchEditText.setVisibility(searching ? View.VISIBLE : View.GONE);
-            headerViewHolder.searchEditText.setText(stories.get(0).title);
-
-            if (searching) {
-                headerViewHolder.loadingIndicator.setVisibility(View.GONE);
-                headerViewHolder.searchEditText.requestFocus();
-                headerViewHolder.searchEditText.setText(lastSearch);
-                headerViewHolder.searchEditText.setSelection(lastSearch.length());
-
-                headerViewHolder.searchEmptyContainer.setVisibility(stories.size() == 1 ? View.VISIBLE : View.GONE);
-                headerViewHolder.noBookmarksLayout.setVisibility(View.GONE);
-            } else {
-                headerViewHolder.noBookmarksLayout.setVisibility((stories.size() == 1 && type == SettingsUtils.getBookmarksIndex(ctx.getResources())) ? View.VISIBLE : View.GONE);
-                headerViewHolder.searchEmptyContainer.setVisibility(View.GONE);
-
-                headerViewHolder.loadingIndicator.setVisibility(stories.size() == 1 && !loadingFailed && !loadingFailedServerError && (type != SettingsUtils.getBookmarksIndex(ctx.getResources())) ? View.VISIBLE : View.GONE);
-            }
-
-            headerViewHolder.showingCachedText.setVisibility(StoriesFragment.showingCached && !searching ? View.VISIBLE : View.GONE);
-
-            headerViewHolder.typeSpinner.setSelection(type);
-
-            TooltipCompat.setTooltipText(headerViewHolder.searchButton, searching ? "Close" : "Search");
-            TooltipCompat.setTooltipText(headerViewHolder.moreButton, "More");
-
-            headerViewHolder.loadingFailedLayout.setVisibility(loadingFailed ? View.VISIBLE : View.GONE);
-            if (loadingFailed) {
-                if (!Utils.isNetworkAvailable(ctx)) {
-                    headerViewHolder.loadingFailedText.setText("No internet connection");
-                } else {
-                    headerViewHolder.loadingFailedText.setText("Loading failed");
-                }
-            }
-
-            headerViewHolder.showCachedButton.setVisibility(loadingFailed && Utils.hasCachedStories(ctx) ? View.VISIBLE : View.GONE);
-
-            headerViewHolder.loadingFailedAlgoliaLayout.setVisibility(loadingFailedServerError ? View.VISIBLE : View.GONE);
         } else if (holder instanceof SubmissionsHeaderViewHolder) {
             final SubmissionsHeaderViewHolder submissionsHeaderViewHolder = (SubmissionsHeaderViewHolder) holder;
 
@@ -347,33 +267,34 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
 
     @Override
     public int getItemViewType(int position) {
-        if (position == 0) {
-            return atSubmissions ? TYPE_HEADER_SUBMISSIONS : TYPE_HEADER_MAIN;
+        if (atSubmissions) {
+            // Submissions path: position 0 is header, rest are stories/comments
+            if (position == 0) {
+                return TYPE_HEADER_SUBMISSIONS;
+            }
+            return stories.get(position).isComment ? TYPE_COMMENT : TYPE_STORY;
         }
 
-        // Check if this is the "Load More" button position
-        // stories[0] is header, so actual story count = stories.size() - 1
-        if (paginationMode && !atSubmissions && position == visibleStoryCount + 1 && visibleStoryCount < stories.size() - 1) {
+        // Non-submissions (StoriesFragment): no header in adapter
+        if (paginationMode && position == visibleStoryCount && visibleStoryCount < stories.size()) {
             return TYPE_LOAD_MORE_BUTTON;
         }
 
-        if (atSubmissions) {
-            return stories.get(position).isComment ? TYPE_COMMENT : TYPE_STORY;
-        } else {
-            return TYPE_STORY;
-        }
+        return TYPE_STORY;
     }
 
     @Override
     public int getItemCount() {
-        if (paginationMode && !atSubmissions && visibleStoryCount < stories.size() - 1) {
-            // Header + visible stories + Load More button
-            // stories[0] is header, stories[1..N] are actual stories
-            // So if visibleStoryCount = 30, we show positions 0-31 (header + 30 stories + button)
-            return visibleStoryCount + 2;
+        if (atSubmissions) {
+            // Submissions still has header at stories[0]
+            return stories.size();
         }
-        // stories[0] is header, stories[1..N] are actual stories
-        // getItemCount should equal stories.size() so positions map directly to indices
+
+        // Non-submissions: stories list contains only actual stories
+        if (paginationMode && visibleStoryCount < stories.size()) {
+            // visible stories + Load More button
+            return visibleStoryCount + 1;
+        }
         return stories.size();
     }
 
@@ -428,119 +349,6 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
             }
         }
     }
-
-    public class MainHeaderViewHolder extends RecyclerView.ViewHolder {
-        public final Spinner typeSpinner;
-        public final LinearLayout container;
-        public final LinearLayout loadingFailedLayout;
-        public final TextView loadingFailedText;
-        public final TextView showingCachedText;
-        public final TextView loadingFailedAlgoliaLayout;
-        public final LinearLayout noBookmarksLayout;
-        public final LinearLayout spinnerContainer;
-        public final LinearLayout searchEmptyContainer;
-        public final RelativeLayout loadingIndicator;
-        public final EditText searchEditText;
-        public final ImageButton moreButton;
-        public final ImageButton searchButton;
-        public final Button retryButton;
-        public final Button showCachedButton;
-
-        public ArrayAdapter<CharSequence> typeAdapter;
-
-        public MainHeaderViewHolder(View view) {
-            super(view);
-
-            final Context ctx = view.getContext();
-
-            loadingFailedLayout = view.findViewById(R.id.stories_header_loading_failed);
-            loadingFailedAlgoliaLayout = view.findViewById(R.id.stories_header_loading_failed_algolia);
-            loadingFailedText = view.findViewById(R.id.stories_header_loading_failed_text);
-            showingCachedText = view.findViewById(R.id.stories_header_cached_stories_header);
-            container = view.findViewById(R.id.stories_header_container);
-            typeSpinner = view.findViewById(R.id.stories_header_spinner);
-            noBookmarksLayout = view.findViewById(R.id.stories_header_no_bookmarks);
-            searchEditText = view.findViewById(R.id.stories_header_search_edittext);
-            moreButton = view.findViewById(R.id.stories_header_more);
-            spinnerContainer = view.findViewById(R.id.stories_header_spinner_container);
-            searchButton = view.findViewById(R.id.stories_header_search_button);
-            searchEmptyContainer = view.findViewById(R.id.stories_header_search_empty_container);
-            retryButton = view.findViewById(R.id.stories_header_retry_button);
-            showCachedButton = view.findViewById(R.id.stories_header_show_cached);
-            loadingIndicator = view.findViewById(R.id.stories_header_loading_indicator);
-
-            retryButton.setOnClickListener((v) -> refreshListener.onRefresh());
-            showCachedButton.setOnClickListener(v -> {
-                if (cachedListener != null) {
-                    cachedListener.onShowCached();
-                }
-            });
-
-            moreButton.setOnClickListener(moreClickListener);
-
-            searchEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
-                @Override
-                public boolean onEditorAction(TextView textView, int actionId, KeyEvent keyEvent) {
-                    boolean isKeyboardSearchAction = actionId == EditorInfo.IME_ACTION_SEARCH;
-                    boolean isHardwareEnterKey = keyEvent != null
-                            && keyEvent.getKeyCode() == KeyEvent.KEYCODE_ENTER
-                            && keyEvent.getAction() == KeyEvent.ACTION_DOWN;
-
-                    if (!isKeyboardSearchAction && !isHardwareEnterKey) {
-                        return false;
-                    }
-
-                    doSearch();
-                    if (textView != null) {
-                        InputMethodManager imm = (InputMethodManager) ctx.getSystemService(Context.INPUT_METHOD_SERVICE);
-                        imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
-                    }
-                    return true;
-                }
-            });
-
-            searchButton.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    searching = !searching;
-                    storiesSearchListener.onSearchStatusChanged();
-
-                    InputMethodManager imm = (InputMethodManager) ctx.getSystemService(Context.INPUT_METHOD_SERVICE);
-                    if (searching) {
-                        imm.toggleSoftInput(InputMethodManager.SHOW_IMPLICIT, 0);
-                    } else {
-                        imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
-                        lastSearch = "";
-                    }
-                }
-            });
-
-            String[] sortingOptions = ctx.getResources().getStringArray(R.array.sorting_options);
-            ArrayList<CharSequence> typeAdapterList = new ArrayList<>(Arrays.asList(sortingOptions));
-            typeAdapter = new ArrayAdapter<>(ctx, R.layout.spinner_top_layout, R.id.selection_dropdown_item_textview, typeAdapterList);
-            typeAdapter.setDropDownViewResource(R.layout.spinner_item_layout);
-
-            typeSpinner.setAdapter(typeAdapter);
-            typeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-                @Override
-                public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
-                    if (i != type) {
-                        typeClickListener.onItemClick(i);
-                    }
-                }
-
-                @Override
-                public void onNothingSelected(AdapterView<?> adapterView) {
-
-                }
-            });
-        }
-
-        private void doSearch() {
-            storiesSearchListener.onQueryTextSubmit(searchEditText.getText().toString());
-        }
-    }
-
 
     public static class SubmissionsHeaderViewHolder extends RecyclerView.ViewHolder {
 
@@ -607,10 +415,6 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
         }
     }
 
-    public void setOnTypeClickListener(ClickListener clickListener) {
-        typeClickListener = clickListener;
-    }
-
     public void setOnLinkClickListener(ClickListener clickListener) {
         linkClickListener = clickListener;
     }
@@ -631,42 +435,12 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
         longClickListener = clickListener;
     }
 
-    public void setOnRefreshListener(RefreshListener listener) {
-        refreshListener = listener;
-    }
-
-    public void setOnShowCachedListener(CachedListener listener) {
-        cachedListener = listener;
-    }
-
-    public void setOnMoreClickListener(View.OnClickListener listener) {
-        moreClickListener = listener;
-    }
-
     public void setOnLoadMoreClickListener(View.OnClickListener listener) {
         loadMoreClickListener = listener;
     }
 
     public interface ClickListener {
         void onItemClick(int position);
-    }
-
-    public void setSearchListener(SearchListener searchListener) {
-        storiesSearchListener = searchListener;
-    }
-
-    public interface SearchListener {
-        void onQueryTextSubmit(String query);
-
-        void onSearchStatusChanged();
-    }
-
-    public interface RefreshListener {
-        void onRefresh();
-    }
-
-    public interface CachedListener {
-        void onShowCached();
     }
 
     public interface LongClickCoordinateListener {
@@ -684,22 +458,21 @@ public class StoryRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.
 
     public void loadNextPage() {
         int oldVisibleCount = visibleStoryCount;
-        // stories[0] is header, actual story count = stories.size() - 1
-        visibleStoryCount = Math.min(visibleStoryCount + PAGINATION_PAGE_SIZE, stories.size() - 1);
+        visibleStoryCount = Math.min(visibleStoryCount + PAGINATION_PAGE_SIZE, stories.size());
 
         // Notify about the new items that are now visible
         int itemsAdded = visibleStoryCount - oldVisibleCount;
         if (itemsAdded > 0) {
-            notifyItemRangeInserted(oldVisibleCount + 1, itemsAdded);
+            notifyItemRangeInserted(oldVisibleCount, itemsAdded);
         }
 
         // Update or remove the button
-        if (visibleStoryCount >= stories.size() - 1) {
+        if (visibleStoryCount >= stories.size()) {
             // All stories are visible, remove the button
-            notifyItemRemoved(visibleStoryCount + 1);
+            notifyItemRemoved(visibleStoryCount);
         } else {
             // More stories remain, update the button text
-            notifyItemChanged(visibleStoryCount + 1);
+            notifyItemChanged(visibleStoryCount);
         }
     }
 

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
@@ -815,7 +815,12 @@ public class Utils {
                 // Check if id parameter is valid
                 if (sId != null && !sId.isEmpty() && TextUtils.isDigitsOnly(sId)) {
                     int id = Integer.parseInt(sId);
-                    openCommentsActivity(id, context);
+                    int scrollToCommentId = -1;
+                    String fragment = uri.getFragment();
+                    if (fragment != null && !fragment.isEmpty() && TextUtils.isDigitsOnly(fragment)) {
+                        scrollToCommentId = Integer.parseInt(fragment);
+                    }
+                    openCommentsActivity(id, scrollToCommentId, context);
                     return;
                 }
             }
@@ -825,9 +830,16 @@ public class Utils {
     }
 
     public static void openCommentsActivity(int id, Context context) {
-        Uri uri = Uri.parse("https://news.ycombinator.com/item").buildUpon()
-                .appendQueryParameter("id", String.valueOf(id))
-                .build();
+        openCommentsActivity(id, -1, context);
+    }
+
+    public static void openCommentsActivity(int id, int scrollToCommentId, Context context) {
+        Uri.Builder builder = Uri.parse("https://news.ycombinator.com/item").buildUpon()
+                .appendQueryParameter("id", String.valueOf(id));
+        if (scrollToCommentId > 0) {
+            builder.fragment(String.valueOf(scrollToCommentId));
+        }
+        Uri uri = builder.build();
 
         Intent intent = new Intent(Intent.ACTION_VIEW, uri);
         intent.setClass(context, CommentsActivity.class);

--- a/app/src/main/res/layout/fragment_stories.xml
+++ b/app/src/main/res/layout/fragment_stories.xml
@@ -6,15 +6,27 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".MainActivity">
 
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/stories_appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        android:stateListAnimator="@null"
+        app:elevation="0dp">
+
+        <include layout="@layout/stories_header" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/stories_swipe_refresh"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/stories_recyclerview"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
             android:clipToPadding="false"
             tools:listitem="@layout/story_list_item" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/stories_header.xml
+++ b/app/src/main/res/layout/stories_header.xml
@@ -225,11 +225,4 @@
 
     </LinearLayout>
 
-    <View
-        android:id="@+id/stories_header_separator"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:alpha="0"
-        android:background="?android:attr/listDivider" />
-
 </LinearLayout>

--- a/app/src/main/res/layout/stories_header.xml
+++ b/app/src/main/res/layout/stories_header.xml
@@ -4,12 +4,13 @@
     android:id="@+id/stories_header_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="38dp"
-    android:layout_marginStart="16dp"
-    android:layout_marginEnd="16dp"
     android:orientation="vertical"
-    android:paddingBottom="24dp">
-    <!-- Above paddings are not respected, set in code -->
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="24dp"
+    android:background="?android:attr/windowBackground"
+    app:layout_scrollFlags="scroll|enterAlways|snap">
+    <!-- paddingTop applied dynamically via window insets -->
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -223,5 +224,12 @@
             android:text="Show cached stories" />
 
     </LinearLayout>
+
+    <View
+        android:id="@+id/stories_header_separator"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:alpha="0"
+        android:background="?android:attr/listDivider" />
 
 </LinearLayout>


### PR DESCRIPTION
The stories header now hides when scrolling down and reappears when scrolling up, giving more screen space to the story list. Also adds support for scrolling directly to a specific comment when opening HN links with fragment anchors.

Addresses #209, #111, #127.

### Changes

- Moved the stories header out of RecyclerView (was position 0) into an `AppBarLayout` with `scroll|enterAlways|snap` scroll flags
- Header fades out as it scrolls away, separator line fades in to visually anchor content
- Tapping the header area scrolls back to top and expands the header
- Extracted all header view binding and logic from `StoryRecyclerViewAdapter` into `StoriesFragment`, simplifying the adapter significantly
- Removed dummy `Story` object at index 0 — adapter now only contains real stories
- Cleaned up unused listener interfaces and dead loading state fields from adapter and `SubmissionsActivity`
- HN URLs with comment anchors (`item?id=X#Y`) now scroll to the target comment once loaded
- `Utils.openCommentsActivity` gained an overload that passes the comment ID via URI fragment

### Testing

- [ ] Scroll down the story list — header should hide smoothly
- [ ] Scroll up slightly — header should reappear with snap behavior
- [ ] Separator line appears when scrolled, disappears at top
- [ ] Tap header area to scroll back to top
- [ ] Story type spinner, search, and more button still work from the header
- [ ] Pull-to-refresh works correctly
- [ ] Pagination mode ("Load more" button) still works
- [ ] Bookmarks and History tabs display correctly
- [ ] Submissions screen (user profile) loads and displays correctly
- [ ] Open a link like `https://news.ycombinator.com/item?id=47282736#47284143` — should scroll to the referenced comment
- [ ] Compact header setting still applies correct padding
- [ ] Foldable/tablet layout unaffected