### PR TITLE
fix: links should open in supported apps if available

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/utils/ContextExtensions.kt
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ContextExtensions.kt
@@ -22,6 +22,10 @@ fun Context.defaultBrowserPackageName(): String? {
         ?.takeUnless { it in InvalidDefaultBrowsers }
 }
 
+fun Context.isInvalidViewHandlerPackage(packageName: String?): Boolean {
+    return packageName != null && packageName in InvalidDefaultBrowsers
+}
+
 /**
  * A list of package names that may be incorrectly resolved as usable browsers by
  * the system.

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Utils.java
@@ -626,37 +626,54 @@ public class Utils {
     }
 
     public static void launchInExternalBrowser(Context ctx, String url) {
-        String defaultBrowserPackageName = ContextExtensionsKt.defaultBrowserPackageName(ctx);
-
         try {
-            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-            if (defaultBrowserPackageName != null) {
-                browserIntent.setPackage(defaultBrowserPackageName);
-            }
-            ctx.startActivity(browserIntent);
+            openExternalUrl(ctx, url);
         } catch (Exception e) {
             // failed for the first time, let's try to guess a fix to the url
             try {
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(URLUtil.guessUrl(url)));
-                if (defaultBrowserPackageName != null) {
-                    browserIntent.setPackage(defaultBrowserPackageName);
-                }
-                ctx.startActivity(browserIntent);
+                openExternalUrl(ctx, URLUtil.guessUrl(url));
             } catch (Exception e1) {
                 // automated fix didn't work, let's try to do it manually
                 try {
                     if (!url.startsWith("http://") && !url.startsWith("https://"))
                         url = "http://" + url;
-                    Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                    if (defaultBrowserPackageName != null) {
-                        browserIntent.setPackage(defaultBrowserPackageName);
-                    }
-                    ctx.startActivity(browserIntent);
+                    openExternalUrl(ctx, url);
                 } catch (Exception e2) {
                     Toast.makeText(ctx, "Couldn't open link to: " + url, Toast.LENGTH_SHORT).show();
                 }
             }
         }
+    }
+
+    private static void openExternalUrl(Context ctx, String url) {
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        String packageName = getPackageForExternalUrl(ctx, browserIntent);
+        if (packageName != null) {
+            browserIntent.setPackage(packageName);
+        }
+        ctx.startActivity(browserIntent);
+    }
+
+    private static String getPackageForExternalUrl(Context ctx, Intent browserIntent) {
+        String defaultBrowserPackageName = ContextExtensionsKt.defaultBrowserPackageName(ctx);
+        if (defaultBrowserPackageName == null) {
+            return null;
+        }
+
+        ResolveInfo resolveInfo = ctx.getPackageManager()
+                .resolveActivity(browserIntent, PackageManager.MATCH_DEFAULT_ONLY);
+        String resolvedPackageName = null;
+        if (resolveInfo != null && resolveInfo.activityInfo != null) {
+            resolvedPackageName = resolveInfo.activityInfo.packageName;
+        }
+
+        // force browser only when VIEW resolves to Harmonic itself (self-loop) or a known bad resolver.
+        if (ctx.getPackageName().equals(resolvedPackageName)
+                || ContextExtensionsKt.isInvalidViewHandlerPackage(ctx, resolvedPackageName)) {
+            return defaultBrowserPackageName;
+        }
+
+        return null;
     }
 
     public static boolean downloadPDF(Context context, String pdfUrl) {


### PR DESCRIPTION
fix #290 

This PR is created with help from Codex. I'm new to Android dev so some things might not be idiomatic. I have manually checked it works.

## Changes

- consolidate duplicate code into one method `openExternalUrl`
- create new method `getPackageForExternalUrl` that uses `ctx.getPackageManager().resolveActivity()` to determine the default app to open the link

## Recording

### Before: youtube link opens in the default browser

https://github.com/user-attachments/assets/e3439a68-4787-43a2-b0e4-5f5834177828

### After: youtube link opens in the youtube app

https://github.com/user-attachments/assets/018922a6-b076-4d71-ac2b-2b609af9f504