### PR TITLE
Add new sharing menu item and update GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "03:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps):"
+      include: "scope"
+    labels:
+      - "gradle"
+      - "dependencies"
+    groups:
+      major:
+        update-types:
+          - "major"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "03:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci):"
+      include: "scope"
+    labels:
+      - "ci"
+      - "dependencies"
+    groups:
+      major:
+        update-types:
+          - "major"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
     commit-message:
       prefix: "chore(gradle):"
     groups:
-      major:
-        update-types:
-          - "major"
       minor-and-patch:
         update-types:
           - "minor"
@@ -28,9 +25,6 @@ updates:
     commit-message:
       prefix: "chore(ci):"
     groups:
-      major:
-        update-types:
-          - "major"
       minor-and-patch:
         update-types:
           - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,7 @@ updates:
       time: "03:00"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps):"
-      include: "scope"
-    labels:
-      - "gradle"
-      - "dependencies"
+      prefix: "chore(gradle):"
     groups:
       major:
         update-types:
@@ -31,10 +27,6 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(ci):"
-      include: "scope"
-    labels:
-      - "ci"
-      - "dependencies"
     groups:
       major:
         update-types:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
           cache: 'gradle'
       - name: Build with Gradle
         run: ./gradlew build --warning-mode all --no-daemon --parallel
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: apks
           path: app/build/outputs/apk

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/gradle-build-action@v3
         with:
           arguments: build --warning-mode all
       - uses: softprops/action-gh-release@v3

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         with:
           arguments: build --warning-mode all
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: app/build/outputs/apk/release/app-release-unsigned.apk

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/CommentsFragment.java
@@ -2373,7 +2373,10 @@ public class CommentsFragment extends Fragment implements CommentsRecyclerViewAd
                     startActivity(ShareUtils.getShareIntent(adapter.story.id));
                 } else if (itemId == R.id.menu_hacker_news_link_title) {
                     startActivity(ShareUtils.getShareIntentWithTitle(adapter.story.title, adapter.story.id));
+                } else if (itemId == R.id.menu_link_title_and_hacker_news_link_title) {
+                    startActivity(ShareUtils.getShareIntentWithTitle(adapter.story.title, adapter.story.id, adapter.story.url));
                 }
+
 
                 return true;
             }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/Changelog.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/Changelog.java
@@ -13,6 +13,7 @@ public class Changelog {
                 "- Always enable foldable support<br>" +
                 "- Added button to only show comment threads where the OP has commented<br>" +
                 "- Added new setting for graying out clicked posts<br>" +
+                "- Added new sharing option for link + HN comments (thanks daniel-egan!)" +
                 "<br>" +
                 "<b>Version 2.4:</b><br>" +
                 "- Redesigned search, including adding search options<br>" +

--- a/app/src/main/java/com/simon/harmonichackernews/utils/ShareUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/ShareUtils.java
@@ -39,4 +39,11 @@ public class ShareUtils {
         return getShareIntent(title + " | " + SHARE_BASE_URL + id);
     }
 
+    public static Intent getShareIntentWithTitle(String title, int id, String url) {
+
+        String content = String.format("%1$s | %2$s\n\n---\n\nHacker News Comments | %3$s", title, url, SHARE_BASE_URL + id);
+
+        return getShareIntent(content);
+    }
+
 }

--- a/app/src/main/res/menu/share_menu.xml
+++ b/app/src/main/res/menu/share_menu.xml
@@ -19,6 +19,6 @@
 
     <item
         android:id="@+id/menu_link_title_and_hacker_news_link_title"
-        android:title="Article and HN link and title" />
+        android:title="Article + HN link and title" />
 
 </menu>

--- a/app/src/main/res/menu/share_menu.xml
+++ b/app/src/main/res/menu/share_menu.xml
@@ -17,4 +17,8 @@
         android:id="@+id/menu_hacker_news_link_title"
         android:title="HN link and title" />
 
+    <item
+        android:id="@+id/menu_link_title_and_hacker_news_link_title"
+        android:title="Article and HN link and title" />
+
 </menu>


### PR DESCRIPTION
Often I want to share both the article link and then the comments that are on HN, so I added a new menu item to allow for that.
- I'm not attached to the formatting that I've done if you think there is a better way to do the layout for the shared content.


I also added dependabot because I noticed some of the GitHub actions were throwing warnings because of Node 20 being deprecated. This lead to me also updating a couple of them considering I was already in the process.
- This will create PRs for dependencies that go out of date, it should group together minor and patch updates, and major updates should become their own PRs