### PR TITLE
feat: add a Mark all as read action to the stories overflow menu

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -2832,9 +2832,21 @@ public class StoriesFragment extends Fragment {
             HistoriesUtils.INSTANCE.addHistories(requireContext(), newlyReadIds);
         }
 
-        if (changed && adapter != null) {
-            adapter.notifyDataSetChanged();
+        if (!changed || adapter == null) {
+            return;
         }
+
+        // When the user hides clicked posts, the now-read rows must leave the
+        // current list immediately, matching the existing clicked-sync path
+        // (refreshClickedState) rather than lingering until the next refresh.
+        if (hideClicked && !isHistoryType(adapter.type)) {
+            if (!removeClickedStoriesFromCurrentList()) {
+                attemptRefresh();
+            }
+            return;
+        }
+
+        adapter.notifyDataSetChanged();
     }
 
     private void removeStoryAt(int index, int loadGeneration, boolean loadVisibleReplacement) {

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -2788,6 +2788,41 @@ public class StoriesFragment extends Fragment {
         HistoriesUtils.INSTANCE.addHistory(requireContext(), story.id);
     }
 
+    private boolean hasLoadedStory() {
+        if (stories == null) {
+            return false;
+        }
+        for (Story story : stories) {
+            if (isMarkableStory(story)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isMarkableStory(Story story) {
+        return story != null && story.loaded && !story.isComment && story.id > 0;
+    }
+
+    private void markAllStoriesRead() {
+        if (stories == null) {
+            return;
+        }
+
+        boolean changed = false;
+        for (Story story : stories) {
+            if (isMarkableStory(story) && !story.clicked) {
+                story.clicked = true;
+                HistoriesUtils.INSTANCE.addHistory(requireContext(), story.id);
+                changed = true;
+            }
+        }
+
+        if (changed && adapter != null) {
+            adapter.notifyDataSetChanged();
+        }
+    }
+
     private void removeStoryAt(int index, int loadGeneration, boolean loadVisibleReplacement) {
         if (index < 0 || index >= stories.size()) {
             return;
@@ -3033,6 +3068,8 @@ public class StoriesFragment extends Fragment {
                     Intent submitIntent = new Intent(getContext(), ComposeActivity.class);
                     submitIntent.putExtra(ComposeActivity.EXTRA_TYPE, ComposeActivity.TYPE_POST);
                     startActivity(submitIntent);
+                } else if (item.getItemId() == R.id.menu_mark_all_read) {
+                    markAllStoriesRead();
                 } else if (item.getItemId() == R.id.menu_clear_history) {
                     HistoriesUtils.INSTANCE.clearHistories(requireContext());
                     loadingFailed = false;
@@ -3056,6 +3093,7 @@ public class StoriesFragment extends Fragment {
         //first only show cache button if we're not already looking at the cache
         boolean cacheInProgress = storyCacheController != null && storyCacheController.isCachingStories();
         menu.findItem(R.id.menu_cache).setVisible(!showingCached && !cacheInProgress);
+        menu.findItem(R.id.menu_mark_all_read).setVisible(!isHistoryType(adapter.type) && hasLoadedStory());
         menu.findItem(R.id.menu_clear_history).setVisible(isHistoryType(adapter.type) && HistoriesUtils.INSTANCE.size() > 0);
         //also if we don't have internet, no need to show at all
         if (getContext() != null) {

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -2788,7 +2788,7 @@ public class StoriesFragment extends Fragment {
         HistoriesUtils.INSTANCE.addHistory(requireContext(), story.id);
     }
 
-    private boolean hasLoadedStory() {
+    private boolean hasMarkableStory() {
         if (stories == null) {
             return false;
         }
@@ -2801,7 +2801,13 @@ public class StoriesFragment extends Fragment {
     }
 
     private boolean isMarkableStory(Story story) {
-        return story != null && story.loaded && !story.isComment && story.id > 0;
+        // A story is markable as long as it has a real HN id and is not a
+        // comment row. We intentionally do NOT require story.loaded: on the
+        // standard feeds the list is pre-populated with placeholder rows whose
+        // JSON has not been fetched yet, and "Mark all as read" should cover
+        // the whole loaded feed, not just the rows the user happened to scroll
+        // far enough to fetch.
+        return story != null && !story.isComment && story.id > 0;
     }
 
     private void markAllStoriesRead() {
@@ -2809,13 +2815,21 @@ public class StoriesFragment extends Fragment {
             return;
         }
 
+        List<Integer> newlyReadIds = new ArrayList<>();
         boolean changed = false;
         for (Story story : stories) {
             if (isMarkableStory(story) && !story.clicked) {
                 story.clicked = true;
-                HistoriesUtils.INSTANCE.addHistory(requireContext(), story.id);
+                newlyReadIds.add(story.id);
                 changed = true;
             }
+        }
+
+        if (!newlyReadIds.isEmpty()) {
+            // Persist every id in a single write instead of one
+            // load/sort/serialize cycle per story (HistoriesUtils.addHistories
+            // de-dupes against existing entries).
+            HistoriesUtils.INSTANCE.addHistories(requireContext(), newlyReadIds);
         }
 
         if (changed && adapter != null) {
@@ -3093,7 +3107,7 @@ public class StoriesFragment extends Fragment {
         //first only show cache button if we're not already looking at the cache
         boolean cacheInProgress = storyCacheController != null && storyCacheController.isCachingStories();
         menu.findItem(R.id.menu_cache).setVisible(!showingCached && !cacheInProgress);
-        menu.findItem(R.id.menu_mark_all_read).setVisible(!isHistoryType(adapter.type) && hasLoadedStory());
+        menu.findItem(R.id.menu_mark_all_read).setVisible(!isHistoryType(adapter.type) && hasMarkableStory());
         menu.findItem(R.id.menu_clear_history).setVisible(isHistoryType(adapter.type) && HistoriesUtils.INSTANCE.size() > 0);
         //also if we don't have internet, no need to show at all
         if (getContext() != null) {

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -3976,9 +3976,21 @@ public class StoriesFragment extends Fragment {
             HistoriesUtils.INSTANCE.addHistories(requireContext(), newlyReadIds);
         }
 
-        if (changed && adapter != null) {
-            adapter.notifyDataSetChanged();
+        if (!changed || adapter == null) {
+            return;
         }
+
+        // When the user hides clicked posts, the now-read rows must leave the
+        // current list immediately, matching the existing clicked-sync path
+        // (refreshClickedState) rather than lingering until the next refresh.
+        if (hideClicked && !isHistoryType(adapter.type)) {
+            if (!removeClickedStoriesFromCurrentList()) {
+                attemptRefresh();
+            }
+            return;
+        }
+
+        adapter.notifyDataSetChanged();
     }
 
     private void removeStoryAt(int index, int loadGeneration, boolean loadVisibleReplacement) {

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -3932,6 +3932,41 @@ public class StoriesFragment extends Fragment {
         HistoriesUtils.INSTANCE.addHistory(requireContext(), story.id);
     }
 
+    private boolean hasLoadedStory() {
+        if (stories == null) {
+            return false;
+        }
+        for (Story story : stories) {
+            if (isMarkableStory(story)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isMarkableStory(Story story) {
+        return story != null && story.loaded && !story.isComment && story.id > 0;
+    }
+
+    private void markAllStoriesRead() {
+        if (stories == null) {
+            return;
+        }
+
+        boolean changed = false;
+        for (Story story : stories) {
+            if (isMarkableStory(story) && !story.clicked) {
+                story.clicked = true;
+                HistoriesUtils.INSTANCE.addHistory(requireContext(), story.id);
+                changed = true;
+            }
+        }
+
+        if (changed && adapter != null) {
+            adapter.notifyDataSetChanged();
+        }
+    }
+
     private void removeStoryAt(int index, int loadGeneration, boolean loadVisibleReplacement) {
         if (index < 0 || index >= stories.size()) {
             return;
@@ -4179,6 +4214,8 @@ public class StoriesFragment extends Fragment {
                     Intent submitIntent = new Intent(getContext(), ComposeActivity.class);
                     submitIntent.putExtra(ComposeActivity.EXTRA_TYPE, ComposeActivity.TYPE_POST);
                     startActivity(submitIntent);
+                } else if (item.getItemId() == R.id.menu_mark_all_read) {
+                    markAllStoriesRead();
                 } else if (item.getItemId() == R.id.menu_clear_history) {
                     HistoriesUtils.INSTANCE.clearHistories(requireContext());
                     loadingFailed = false;
@@ -4204,6 +4241,7 @@ public class StoriesFragment extends Fragment {
         boolean hasVisibleStories = adapter != null && adapter.getVisibleStoryItemCount() > 0;
         menu.findItem(R.id.menu_cache).setVisible(
                 hasVisibleStories && !showingCached && !cacheInProgress);
+        menu.findItem(R.id.menu_mark_all_read).setVisible(!isHistoryType(adapter.type) && hasLoadedStory());
         menu.findItem(R.id.menu_clear_history).setVisible(isHistoryType(adapter.type) && HistoriesUtils.INSTANCE.size() > 0);
         //also if we don't have internet, no need to show at all
         if (getContext() != null) {

--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -3932,7 +3932,7 @@ public class StoriesFragment extends Fragment {
         HistoriesUtils.INSTANCE.addHistory(requireContext(), story.id);
     }
 
-    private boolean hasLoadedStory() {
+    private boolean hasMarkableStory() {
         if (stories == null) {
             return false;
         }
@@ -3945,7 +3945,13 @@ public class StoriesFragment extends Fragment {
     }
 
     private boolean isMarkableStory(Story story) {
-        return story != null && story.loaded && !story.isComment && story.id > 0;
+        // A story is markable as long as it has a real HN id and is not a
+        // comment row. We intentionally do NOT require story.loaded: on the
+        // standard feeds the list is pre-populated with placeholder rows whose
+        // JSON has not been fetched yet, and "Mark all as read" should cover
+        // the whole loaded feed, not just the rows the user happened to scroll
+        // far enough to fetch.
+        return story != null && !story.isComment && story.id > 0;
     }
 
     private void markAllStoriesRead() {
@@ -3953,13 +3959,21 @@ public class StoriesFragment extends Fragment {
             return;
         }
 
+        List<Integer> newlyReadIds = new ArrayList<>();
         boolean changed = false;
         for (Story story : stories) {
             if (isMarkableStory(story) && !story.clicked) {
                 story.clicked = true;
-                HistoriesUtils.INSTANCE.addHistory(requireContext(), story.id);
+                newlyReadIds.add(story.id);
                 changed = true;
             }
+        }
+
+        if (!newlyReadIds.isEmpty()) {
+            // Persist every id in a single write instead of one
+            // load/sort/serialize cycle per story (HistoriesUtils.addHistories
+            // de-dupes against existing entries).
+            HistoriesUtils.INSTANCE.addHistories(requireContext(), newlyReadIds);
         }
 
         if (changed && adapter != null) {
@@ -4241,7 +4255,7 @@ public class StoriesFragment extends Fragment {
         boolean hasVisibleStories = adapter != null && adapter.getVisibleStoryItemCount() > 0;
         menu.findItem(R.id.menu_cache).setVisible(
                 hasVisibleStories && !showingCached && !cacheInProgress);
-        menu.findItem(R.id.menu_mark_all_read).setVisible(!isHistoryType(adapter.type) && hasLoadedStory());
+        menu.findItem(R.id.menu_mark_all_read).setVisible(!isHistoryType(adapter.type) && hasMarkableStory());
         menu.findItem(R.id.menu_clear_history).setVisible(isHistoryType(adapter.type) && HistoriesUtils.INSTANCE.size() > 0);
         //also if we don't have internet, no need to show at all
         if (getContext() != null) {

--- a/app/src/main/java/com/simon/harmonichackernews/utils/HistoriesUtils.kt
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/HistoriesUtils.kt
@@ -27,6 +27,19 @@ object HistoriesUtils {
         }
     }
 
+    fun addHistories(context: Context, ids: Collection<Int>) {
+        val newIds = ids.filter { isHistoryExist(it).not() }.distinct()
+        if (newIds.isEmpty()) {
+            return
+        }
+        val now = System.currentTimeMillis()
+        for (id in newIds) {
+            histories.add(History(id, now))
+        }
+        UtilsKt.addHistories(context, newIds)
+        changeVersion++
+    }
+
     fun getHistorybyId(id: Int): History? {
         return histories.find { it.id == id }
     }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/HistoriesUtils.kt
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/HistoriesUtils.kt
@@ -34,6 +34,19 @@ object HistoriesUtils {
         }
     }
 
+    fun addHistories(context: Context, ids: Collection<Int>) {
+        val newIds = ids.filter { isHistoryExist(it).not() }.distinct()
+        if (newIds.isEmpty()) {
+            return
+        }
+        val now = System.currentTimeMillis()
+        for (id in newIds) {
+            histories.add(History(id, now))
+        }
+        UtilsKt.addHistories(context, newIds)
+        changeVersion++
+    }
+
     fun getHistorybyId(id: Int): History? {
         return histories.find { it.id == id }
     }

--- a/app/src/main/java/com/simon/harmonichackernews/utils/UtilsKt.kt
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/UtilsKt.kt
@@ -65,6 +65,19 @@ object UtilsKt {
         saveHistories(ctx, histories)
     }
 
+    fun addHistories(ctx: Context, ids: Collection<Int>) {
+        if (ids.isEmpty()) {
+            return
+        }
+        val histories: MutableList<History> = loadHistories(ctx, false)
+        val now = System.currentTimeMillis()
+        for (id in ids) {
+            histories.add(History(id, now))
+        }
+        histories.sortByDescending { it.created }
+        saveHistories(ctx, histories)
+    }
+
     fun removeHistory(ctx: Context, id: Int) {
         val bookmarks: MutableList<History> = loadHistories(ctx, false)
 

--- a/app/src/main/java/com/simon/harmonichackernews/utils/UtilsKt.kt
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/UtilsKt.kt
@@ -1,0 +1,26 @@
+package com.simon.harmonichackernews.utils
+
+import android.content.Context
+import com.simon.harmonichackernews.data.History
+
+object UtilsKt {
+    fun addHistories(ctx: Context, ids: Collection<Int>) {
+        if (ids.isEmpty()) {
+            return
+        }
+        val histories = HistoriesUtils.loadHistories(ctx, false)
+        val now = System.currentTimeMillis()
+        for (id in ids) {
+            histories.add(History(id, now))
+        }
+        histories.sortByDescending { it.created }
+        val serializedHistories = histories.joinToString("-") { history ->
+            "${history.id}q${history.created}"
+        }
+        SettingsUtils.saveStringToSharedPreferences(
+            ctx,
+            HistoriesUtils.KEY_SHARED_PREFERENCES_HISTORIES,
+            serializedHistories
+        )
+    }
+}

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -18,6 +18,11 @@
         android:title="Cache stories" />
 
     <item
+        android:id="@+id/menu_mark_all_read"
+        android:title="Mark all as read"
+        android:visible="false" />
+
+    <item
         android:id="@+id/menu_clear_history"
         android:title="Clear history"
         android:visible="false" />

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -18,6 +18,11 @@
         android:title="@string/cache_stories_title" />
 
     <item
+        android:id="@+id/menu_mark_all_read"
+        android:title="Mark all as read"
+        android:visible="false" />
+
+    <item
         android:id="@+id/menu_clear_history"
         android:title="Clear history"
         android:visible="false" />


### PR DESCRIPTION
## Summary

Adds a "Mark all as read" action to the stories overflow menu. It marks every story in the current list as read in one step, reusing the existing `Story.clicked` + `HistoriesUtils` per-story pattern that already backs the long-press "Mark as read" item.

- New `menu_mark_all_read` item in `main_menu.xml`, shown on non-history story lists when at least one markable story is loaded and hidden otherwise (mirroring the conditional visibility of "Clear history").
- `markAllStoriesRead()` collects the newly-read ids and persists them through a single batched `HistoriesUtils.addHistories(...)` write rather than one load/sort/serialize cycle per story, so the action stays cheap on long lists.
- Marking covers placeholder rows that carry a real HN id before their JSON is fetched, so the whole loaded feed is marked, not only the rows scrolled into view.
- When "Hide clicked posts" is enabled, the now-read rows are removed from the current list via the existing `removeClickedStoriesFromCurrentList()` sync path (falling back to a refresh) instead of lingering until the next manual refresh.

## Why this matters

Issue #314 asks for a way to mark all currently-seen stories as read at once. The app already tracks per-story read state and exposes a per-story "Mark as read", but there was no bulk action; the overflow menu (next to "Clear history") is the natural home for it.

## Testing

Manual reasoning against the existing read-state paths (no automated UI test harness in the repo):
- Unread list: invoking the action marks every story read, persists each id, and re-renders grayed/hidden per the user's preference.
- Idempotent: invoking again when everything is already read performs no further history writes (de-duped) and triggers no spurious refresh.
- Mixed state: only previously-unread rows are added to history; already-read rows are untouched and not duplicated.
- Hide-clicked on: the now-read rows leave the current list immediately.

Fixes #314
