### PR TITLE
Ignore null content in AI summary responses

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/network/SummaryManager.java
+++ b/app/src/main/java/com/simon/harmonichackernews/network/SummaryManager.java
@@ -385,7 +385,7 @@ public class SummaryManager {
                 JSONArray choices = event.optJSONArray("choices");
                 JSONObject choice = choices == null ? null : choices.optJSONObject(0);
                 JSONObject delta = choice == null ? null : choice.optJSONObject("delta");
-                chunk = delta == null ? "" : delta.optString("content", "");
+                chunk = (delta == null || delta.isNull("content")) ? "" : delta.optString("content", "");
             }
 
             appendSummaryChunk(summary, chunk, callback);
@@ -412,7 +412,7 @@ public class SummaryManager {
             JSONArray choices = response.optJSONArray("choices");
             JSONObject choice = choices == null ? null : choices.optJSONObject(0);
             JSONObject message = choice == null ? null : choice.optJSONObject("message");
-            return message == null ? "" : message.optString("content", "");
+            return (message == null || message.isNull("content")) ? "" : message.optString("content", "");
         } catch (JSONException e) {
             throw new IOException("Invalid API response", e);
         }


### PR DESCRIPTION
DeepSeek Models can stream chunks with `content: null`, which are automatically converted in `"null"`, see the attached screenshot.

This has been tested with the official OpenAI-compatible endpoint https://api.deepseek.com with both `deepseek-v4-flash` and `deepseek-v4-pro`.

This change ignores null content in both streaming and non-streaming responses for OpenAI-compatible responses.

Before:
<img width="318" height="693" alt="The AI Summary is starting with a lot of null tokens" src="https://github.com/user-attachments/assets/e3080904-3f23-4c01-b3f7-3b6c2f9630ee" />

After:
<img width="318" height="693" alt="The AI Summary is behaving normally" src="https://github.com/user-attachments/assets/f0c1170d-3775-455f-ab7d-d0cbae16973e" />

More details: the bug has been reproduced in Harmonic `3.1.2`, running on Android 16.