### PR TITLE
Fix username handling with leading/trailing spaces

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/utils/AccountUtils.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/AccountUtils.java
@@ -22,11 +22,12 @@ public class AccountUtils {
 
 
     public static String getAccountUsername(Context ctx) {
-        return SettingsUtils.readStringFromSharedPreferences(ctx, KEY_UNENCRYPTED_SHARED_PREFERENCES_USERNAME);
+        String username = SettingsUtils.readStringFromSharedPreferences(ctx, KEY_UNENCRYPTED_SHARED_PREFERENCES_USERNAME);
+        return username == null ? null : username.trim();
     }
 
     public static void setAccountUsername(Context ctx, String username) {
-        SettingsUtils.saveStringToSharedPreferences(ctx, KEY_UNENCRYPTED_SHARED_PREFERENCES_USERNAME, username);
+        SettingsUtils.saveStringToSharedPreferences(ctx, KEY_UNENCRYPTED_SHARED_PREFERENCES_USERNAME, username == null ? null : username.trim());
     }
 
     public static boolean hasAccountDetails(Context ctx) {


### PR DESCRIPTION
## Description

Fixes an issue where leading or trailing whitespace in a Hacker News username could cause the profile page to fail loading.

## Changes

- Trim the username when storing it in `AccountUtils`.
- Trim the username when reading it from `SharedPreferences`.
- Leave the password unchanged.

## Testing

Tested with a Hacker News username containing a trailing space.

### Before:
The profile showed `Loading failed`.

<img width="250" height="500" alt="harmonic_viewProfileError" src="https://github.com/user-attachments/assets/5d6e62c7-a691-4d42-90e8-aa55910c6a11" />


### After:
The profile loads successfully after trimming the username.

<img width="250" height="500" alt="harmonic_viewProfileCorrection" src="https://github.com/user-attachments/assets/cfd5c8ac-e491-4d30-ba87-026a11dd617d" />

