### PR TITLE
Add swipe-to-dismiss for main feed stories

### DIFF
--- a/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
+++ b/app/src/main/java/com/simon/harmonichackernews/StoriesFragment.java
@@ -47,6 +47,7 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
@@ -67,6 +68,7 @@ import com.google.android.material.datepicker.MaterialDatePicker;
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
 import com.google.android.material.search.SearchBar;
+import com.google.android.material.snackbar.Snackbar;
 import com.simon.harmonichackernews.adapters.StoryDisplaySettings;
 import com.simon.harmonichackernews.adapters.StoryRecyclerViewAdapter;
 import com.simon.harmonichackernews.data.Bookmark;
@@ -79,6 +81,7 @@ import com.simon.harmonichackernews.network.JSONParser;
 import com.simon.harmonichackernews.network.NetworkComponent;
 import com.simon.harmonichackernews.network.UserActions;
 import com.simon.harmonichackernews.utils.AccountUtils;
+import com.simon.harmonichackernews.utils.DismissedStoryStore;
 import com.simon.harmonichackernews.utils.FontUtils;
 import com.simon.harmonichackernews.utils.FoldableSplitInitializer;
 import com.simon.harmonichackernews.utils.HistoriesUtils;
@@ -132,6 +135,7 @@ public class StoriesFragment extends Fragment {
     private AppBarLayout.OnOffsetChangedListener appBarOffsetChangedListener;
     private RecyclerView.OnScrollListener recyclerViewScrollListener;
     private RecyclerView.OnScrollListener searchRecyclerViewScrollListener;
+    private ItemTouchHelper mainStorySwipeHelper;
     private RecyclerView.AdapterDataObserver storyAdapterDataObserver;
     private RecyclerView.AdapterDataObserver searchStoryAdapterDataObserver;
     private MaterialButtonToggleGroup.OnButtonCheckedListener userItemFilterCheckedListener;
@@ -632,6 +636,7 @@ public class StoriesFragment extends Fragment {
         setupAdapter();
         mainRecyclerView.setAdapter(mainAdapter);
         searchRecyclerView.setAdapter(searchAdapter);
+        setupMainStorySwipeHelper();
         registerStoryAdapterDataObservers();
         syncActiveStoryListToSearchState();
         applySearchRecyclerVisibility(false);
@@ -1255,6 +1260,139 @@ public class StoriesFragment extends Fragment {
                                         @NonNull LinearLayoutManager targetLayoutManager) {
         targetRecyclerView.setHasFixedSize(true);
         targetRecyclerView.setLayoutManager(targetLayoutManager);
+    }
+
+    private void setupMainStorySwipeHelper() {
+        mainStorySwipeHelper = new ItemTouchHelper(new ItemTouchHelper.SimpleCallback(0, 0) {
+            @Override
+            public int getMovementFlags(@NonNull RecyclerView recyclerView,
+                                         @NonNull RecyclerView.ViewHolder viewHolder) {
+                if (!isDismissibleMainStoryFeed()
+                        || !(viewHolder instanceof StoryRecyclerViewAdapter.StoryViewHolder)) {
+                    return 0;
+                }
+                return makeMovementFlags(0, ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT);
+            }
+
+            @Override
+            public boolean onMove(@NonNull RecyclerView recyclerView,
+                                  @NonNull RecyclerView.ViewHolder viewHolder,
+                                  @NonNull RecyclerView.ViewHolder target) {
+                return false;
+            }
+
+            @Override
+            public void onSwiped(@NonNull RecyclerView.ViewHolder viewHolder, int direction) {
+                int position = viewHolder.getAbsoluteAdapterPosition();
+                if (!isDismissibleMainStoryFeed()
+                        || position < 0
+                        || position >= mainStories.size()) {
+                    if (mainAdapter != null
+                            && position >= 0
+                            && position < mainAdapter.getItemCount()) {
+                        mainAdapter.notifyItemChanged(position);
+                    }
+                    return;
+                }
+
+                Story story = mainStories.get(position);
+                StoryRecyclerViewAdapter dismissalAdapter = mainAdapter;
+                List<Story> dismissalStories = mainStories;
+                int dismissalType = mainAdapter.type;
+                int loadedToBeforeRemoval = loadedTo;
+                int removalGeneration = storyListGeneration;
+                removeStoryAt(position, removalGeneration, true);
+                DismissedStoryStore.dismiss(requireContext(), story.id);
+
+                Snackbar.make(binding.getRoot(), "Story hidden", Snackbar.LENGTH_LONG)
+                        .setAction("UNDO", v -> restoreDismissedStory(
+                                story,
+                                position,
+                                loadedToBeforeRemoval,
+                                removalGeneration,
+                                dismissalAdapter,
+                                dismissalStories,
+                                dismissalType))
+                        .show();
+            }
+        });
+        mainStorySwipeHelper.attachToRecyclerView(mainRecyclerView);
+    }
+
+    private boolean isDismissibleMainStoryFeed() {
+        if (searching || adapter == null || adapter != mainAdapter) {
+            return false;
+        }
+
+        switch (getCurrentStoryType()) {
+            case TOP_STORIES:
+            case NEW_STORIES:
+            case BEST_STORIES:
+            case ASK_HN:
+            case SHOW_HN:
+            case HN_JOBS:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean isCurrentMainStoryUndoContext(
+            @NonNull StoryRecyclerViewAdapter expectedAdapter,
+            @NonNull List<Story> expectedStories,
+            int expectedType) {
+        return isAdded()
+                && getView() != null
+                && !searching
+                && adapter == expectedAdapter
+                && stories == expectedStories
+                && expectedAdapter.type == expectedType;
+    }
+
+    private void restoreDismissedStory(@NonNull Story story,
+                                       int originalPosition,
+                                       int loadedToBeforeRemoval,
+                                       int removalGeneration,
+                                       @NonNull StoryRecyclerViewAdapter expectedAdapter,
+                                       @NonNull List<Story> expectedStories,
+                                       int expectedType) {
+        Context context = getContext();
+        if (context == null) {
+            return;
+        }
+        if (!isCurrentMainStoryUndoContext(expectedAdapter, expectedStories, expectedType)) {
+            DismissedStoryStore.restore(context, story.id);
+            return;
+        }
+
+        boolean sameGeneration = isCurrentStoryActionContext(
+                removalGeneration, expectedAdapter, expectedStories);
+        DismissedStoryStore.restore(context, story.id);
+        for (Story existingStory : mainStories) {
+            if (existingStory.id == story.id) {
+                return;
+            }
+        }
+
+        int restorePosition = Math.min(originalPosition, mainStories.size());
+        mainStories.add(restorePosition, story);
+        if (sameGeneration && originalPosition <= loadedToBeforeRemoval) {
+            loadedTo = Math.min(mainStories.size() - 1, loadedTo + 1);
+        }
+
+        if (mainAdapter.paginationMode) {
+            mainAdapter.notifyDataSetChanged();
+        } else {
+            mainAdapter.notifyItemInserted(restorePosition);
+            mainAdapter.updateStoryIndicesFromPosition(restorePosition);
+        }
+
+        if (!story.loaded) {
+            loadStory(story, 0, storyListGeneration);
+        }
+        if (sameGeneration) {
+            loadVisibleStories(storyListGeneration);
+        }
     }
 
     private void configureStoryItemAnimator(@Nullable RecyclerView.ItemAnimator itemAnimator) {
@@ -3716,6 +3854,10 @@ public class StoriesFragment extends Fragment {
         if (mainRecyclerView != null || searchRecyclerView != null) {
             cancelSearchContentExitAnimation(false);
             if (mainRecyclerView != null) {
+                if (mainStorySwipeHelper != null) {
+                    mainStorySwipeHelper.attachToRecyclerView(null);
+                    mainStorySwipeHelper = null;
+                }
                 if (recyclerViewScrollListener != null) {
                     mainRecyclerView.removeOnScrollListener(recyclerViewScrollListener);
                 }
@@ -4704,6 +4846,11 @@ public class StoriesFragment extends Fragment {
         Context ctx = getContext();
 
         for (int id : itemIds) {
+            if (ctx != null
+                    && isDismissibleMainStoryFeed()
+                    && DismissedStoryStore.isDismissed(ctx, id)) {
+                continue;
+            }
             if (hideClicked && HistoriesUtils.INSTANCE.isHistoryExist(id)) {
                 continue;
             }
@@ -6048,11 +6195,22 @@ public class StoriesFragment extends Fragment {
         applySearchRecyclerVisibility(false);
     }
 
+    private ArrayList<Story> filterDismissedMainStories(List<Story> sourceStories) {
+        ArrayList<Story> filteredStories = new ArrayList<>();
+        Context context = getContext();
+        for (Story story : sourceStories) {
+            if (context == null || !DismissedStoryStore.isDismissed(context, story.id)) {
+                filteredStories.add(story);
+            }
+        }
+        return filteredStories;
+    }
+
     private void showCachedStories() {
         showingCached = true;
         swipeRefreshLayout.setRefreshing(false);
 
-        replaceStories(Utils.loadCachedStories(getContext()));
+        replaceStories(filterDismissedMainStories(Utils.loadCachedStories(getContext())));
         loadedTo = stories.size() - 1;
         loadingFailed = false;
         loadingFailedServerError = false;

--- a/app/src/main/java/com/simon/harmonichackernews/utils/DismissedStoryStore.java
+++ b/app/src/main/java/com/simon/harmonichackernews/utils/DismissedStoryStore.java
@@ -1,0 +1,35 @@
+package com.simon.harmonichackernews.utils;
+
+import android.content.Context;
+
+import java.util.Set;
+
+/** Stores story IDs dismissed from the main story feed. */
+public final class DismissedStoryStore {
+    private static final String KEY_DISMISSED_STORY_IDS =
+            "com.simon.harmonichackernews.KEY_DISMISSED_STORY_IDS";
+
+    private DismissedStoryStore() {
+    }
+
+    public static boolean isDismissed(Context context, int storyId) {
+        return getDismissedIds(context).contains(storyId);
+    }
+
+    public static void dismiss(Context context, int storyId) {
+        Set<Integer> dismissedIds = getDismissedIds(context);
+        dismissedIds.add(storyId);
+        SettingsUtils.saveIntSetToSharedPreferences(context, KEY_DISMISSED_STORY_IDS, dismissedIds);
+    }
+
+    public static void restore(Context context, int storyId) {
+        Set<Integer> dismissedIds = getDismissedIds(context);
+        if (dismissedIds.remove(storyId)) {
+            SettingsUtils.saveIntSetToSharedPreferences(context, KEY_DISMISSED_STORY_IDS, dismissedIds);
+        }
+    }
+
+    private static Set<Integer> getDismissedIds(Context context) {
+        return SettingsUtils.readIntSetFromSharedPreferences(context, KEY_DISMISSED_STORY_IDS);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Implements the swipe-to-dismiss functionality proposed in #354, allowing stories to be quickly removed from the main story feeds with a left or right swipe.

Sometimes I read a story and don't want to see it again while browsing the feed. 
Instead of leaving it in the list, I can simply swipe it away and continue reading.

This is useful for keeping the feed focused on stories I haven't seen yet.

## Why is this useful?

There are several situations where I may want to hide a story:

-  **Already read a story**  
  I finished reading a story and don't want it to appear again while scrolling.

-  **Already know about it**  
  I recognize a story or topic and want to skip it without opening it.

-  **Not interested in a particular story**  
  The story isn't relevant to me, so I can quickly remove it from my feed.

-  **Clean up my feed**  
  After browsing for a while, I can remove stories I've already gone through and keep the feed focused.

-  **Avoid seeing the same story again**  
  Dismissed stories stay hidden even after refreshing the feed or reopening the app.

-  **Quick interaction**  
  Instead of opening a menu or navigating somewhere else, I can simply swipe the story away.

## Features

- Swipe left or right to dismiss a story.
- Shows a `Story hidden` Snackbar with an `UNDO` action.
- Undo restores the story to its original feed when that feed context is still valid.
- Prevents Undo from inserting a story into a different active feed.
- Dismissed stories remain hidden after refreshing the feed.
- Dismissed stories remain hidden after restarting the app.
- Handles Fragment/view lifecycle safely.
- Does not modify Hacker News data or remove anything from the server.

## Supported feeds

Swipe-to-dismiss is currently enabled for:

- Top Stories
- New Stories
- Best Stories
- Ask HN
- Show HN
- Jobs

Search and other special feeds are intentionally not included.

## Persistence

Dismissed story IDs are stored locally using `SharedPreferences`.

The dismissal is local to the app. It does not modify, delete, or interact with the original Hacker News story.

## Undo

If I accidentally dismiss a story, the Snackbar provides an `UNDO` action.

For example:

`Read story → Swipe away → Accidentally dismissed → UNDO → Story restored`

Undo also handles feed changes safely.

For example:

`Top Stories → Swipe story → Switch to New Stories → UNDO → Return to Top Stories → Story is visible again`

The dismissed story is restored to its original feed without being inserted into the currently active different feed.

So if a story was dismissed from Top Stories and I switch to New Stories before pressing `UNDO`, the story will not appear inside New Stories. After returning to Top Stories, the story appears again because the dismissal was undone.

## Demo

### 1. Swipe to dismiss and Undo


https://github.com/user-attachments/assets/888d2ad8-496e-4250-9413-d07958fe6d3a

Example:

`Read story → Swipe → Story hidden → UNDO → Story comes back`

### 2. Undo after switching feeds


https://github.com/user-attachments/assets/d507cf26-7ab5-48d4-89f7-08138c867fe8

Example:

`Top Stories → Swipe story → Switch to New Stories → UNDO → Return to Top Stories → Story is visible again`

The dismissed story is restored to its original feed without being inserted into the currently active feed.

### 3. Dismissal persists after app restart

https://github.com/user-attachments/assets/33a9123d-3acd-45c3-94bf-4568eb4bc6a9

Example:

`Swipe story → Close app → Reopen app → Story remains hidden`

## Testing

- `./gradlew assembleDebug` ✅
- `./gradlew lintDebug` ✅
- `git diff --check` ✅

### Manual testing

- Swipe story → Undo
- Top Stories → swipe story → switch to New Stories → Undo → return to Top Stories → verify story is visible again
- Swipe story → refresh feed → verify story remains hidden
- Swipe story → close app → reopen app → verify story remains hidden
- Verify dismissed stories are not inserted into another feed
- Verify search feed is unaffected
- Verify dismissed stories do not affect Hacker News/server data

## Related issue

Closes #354